### PR TITLE
Remove hardcoded brandName

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -36,7 +36,6 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
-            ->brandName('Pelican')
             ->homeUrl('/')
             ->favicon('/pelican.ico')
             ->profile(EditProfile::class, false)

--- a/config/app.php
+++ b/config/app.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Facade;
 
 return [
 
-    'name' => 'Pelican',
+    'name' => env('APP_NAME', 'Pelican'),
 
     'version' => 'canary',
 


### PR DESCRIPTION
Removes the hardcoded brandName. Now it will use the app name - which is customizable.
Also added back the env variable `APP_NAME`.