### PR TITLE
Add back config variable for redis client

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -46,6 +46,8 @@ return [
     ],
 
     'redis' => [
+        'client' => env('REDIS_CLIENT', 'predis'),
+
         'default' => [
             'scheme' => env('REDIS_SCHEME', 'tcp'),
             'path' => env('REDIS_PATH', '/run/redis/redis.sock'),


### PR DESCRIPTION
Otherwise you get `Class 'Redis' not found` errors when using redis.