### PR TITLE
add dependabot.yml too keep actions up2date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/" # Must be set to / although they're located in .github/workflows
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR enable dependabot to keep gihub-actions up2date. You must setup dependabot in the repo settings