### PR TITLE
Make deploy.locations optional [backwards compat] as it has been removed

### DIFF
--- a/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
@@ -60,7 +60,7 @@ class StoreServerRequest extends ApplicationApiRequest
             'deploy.dedicated_ip' => 'required_with:deploy,boolean',
             'deploy.port_range' => 'array',
             'deploy.port_range.*' => 'string',
-            'start_on_completion' => 'sometimes|boolean'
+            'start_on_completion' => 'sometimes|boolean',
         ];
     }
 

--- a/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
@@ -55,8 +55,10 @@ class StoreServerRequest extends ApplicationApiRequest
 
             // Automatic deployment rules
             'deploy' => 'sometimes|required|array',
+            'deploy.locations' => 'array',
+            'deploy.locations.*' => 'required_with:deploy.locations,integer|min:1',
             'deploy.dedicated_ip' => 'required_with:deploy,boolean',
-            'deploy.port_range' => 'array',
+            'deploy.port_range' => 'array', 
             'deploy.port_range.*' => 'string',
 
             'start_on_completion' => 'sometimes|boolean',

--- a/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
@@ -58,10 +58,9 @@ class StoreServerRequest extends ApplicationApiRequest
             'deploy.locations' => 'array',
             'deploy.locations.*' => 'required_with:deploy.locations,integer|min:1',
             'deploy.dedicated_ip' => 'required_with:deploy,boolean',
-            'deploy.port_range' => 'array', 
+            'deploy.port_range' => 'array',
             'deploy.port_range.*' => 'string',
-
-            'start_on_completion' => 'sometimes|boolean',
+            'start_on_completion' => 'sometimes|boolean'
         ];
     }
 

--- a/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
@@ -55,8 +55,6 @@ class StoreServerRequest extends ApplicationApiRequest
 
             // Automatic deployment rules
             'deploy' => 'sometimes|required|array',
-            'deploy.locations' => 'array',
-            'deploy.locations.*' => 'integer|min:1',
             'deploy.dedicated_ip' => 'required_with:deploy,boolean',
             'deploy.port_range' => 'array',
             'deploy.port_range.*' => 'string',


### PR DESCRIPTION
The locations functionality was removed from the panel, and will be replaced with tags shortly.
The API has to be changed so that it does not force validation of the location data.