### PR TITLE
Fix artisan call in AppSettingsCommand

### DIFF
--- a/app/Console/Commands/Environment/AppSettingsCommand.php
+++ b/app/Console/Commands/Environment/AppSettingsCommand.php
@@ -118,9 +118,9 @@ class AppSettingsCommand extends Command
         }
 
         if ($this->variables['QUEUE_CONNECTION'] !== 'sync') {
-            Artisan::call('p:environment:queue-service', $redisUsed ? [
-                '--use-redis' => true,
-            ] : []);
+            Artisan::call('p:environment:queue-service', [
+                '--use-redis' => $redisUsed,
+            ]);
         }
 
         $this->info($this->console->output());
@@ -129,7 +129,7 @@ class AppSettingsCommand extends Command
     }
 
     /**
-     * Request connection details and verify them.
+     * Request redis connection details and verify them.
      */
     private function requestRedisSettings(): void
     {

--- a/app/Console/Commands/Environment/AppSettingsCommand.php
+++ b/app/Console/Commands/Environment/AppSettingsCommand.php
@@ -118,7 +118,9 @@ class AppSettingsCommand extends Command
         }
 
         if ($this->variables['QUEUE_CONNECTION'] !== 'sync') {
-            Artisan::call('p:environment:queue-service', $redisUsed ? ['--use-redis'] : []);
+            Artisan::call('p:environment:queue-service', $redisUsed ? [
+                '--use-redis' => true,
+            ] : []);
         }
 
         $this->info($this->console->output());


### PR DESCRIPTION
Fixes `The "1" argument does not exists` error.