### PR TITLE
Replace DB check in MakeUserCommand

### DIFF
--- a/app/Console/Commands/User/MakeUserCommand.php
+++ b/app/Console/Commands/User/MakeUserCommand.php
@@ -30,7 +30,7 @@ class MakeUserCommand extends Command
     public function handle(): int
     {
         try {
-            DB::select('select 1 where 1');
+            DB::connection()->getPdo();
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
 


### PR DESCRIPTION
Replaces the `select 1 where 1` with a proper connection test. This prevents errors on MariaDB 10.3. (apparently `select 1 where 1` only works on 10.4+)