### PR TITLE
Fix default sqlite database path in setup command

### DIFF
--- a/app/Console/Commands/Environment/DatabaseSettingsCommand.php
+++ b/app/Console/Commands/Environment/DatabaseSettingsCommand.php
@@ -98,7 +98,7 @@ class DatabaseSettingsCommand extends Command
         } elseif ($this->variables['DB_CONNECTION'] === 'sqlite') {
             $this->variables['DB_DATABASE'] = $this->option('database') ?? $this->ask(
                 'Database Path',
-                config('database.connections.sqlite.database', database_path('database.sqlite'))
+                config('database.connections.sqlite.database', 'database.sqlite')
             );
         }
 


### PR DESCRIPTION
Since https://github.com/pelican-dev/panel/commit/a9e58bb493b9e087e54fbe5c0c567aa3904a6127 the database path is no longer absolute but relative.