### PR TITLE
Use env value instead of config value for database path

### DIFF
--- a/app/Console/Commands/Environment/DatabaseSettingsCommand.php
+++ b/app/Console/Commands/Environment/DatabaseSettingsCommand.php
@@ -98,7 +98,7 @@ class DatabaseSettingsCommand extends Command
         } elseif ($this->variables['DB_CONNECTION'] === 'sqlite') {
             $this->variables['DB_DATABASE'] = $this->option('database') ?? $this->ask(
                 'Database Path',
-                config('database.connections.sqlite.database', 'database.sqlite')
+                env('DB_DATABASE', 'database.sqlite')
             );
         }
 


### PR DESCRIPTION
This (finally) fixes the wrong default path for sqlite.