### PR TITLE
Update release workflow for new parameter format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,25 +60,6 @@ jobs:
         with:
           draft: true
           prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
-
-      - name: Upload release archive
-        id: upload-release-archive
-        uses: actions/upload-release-asset@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: panel.tar.gz
-          asset_name: panel.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload release checksum
-        id: upload-release-checksum
-        uses: actions/upload-release-asset@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./checksum.txt
-          asset_name: checksum.txt
-          asset_content_type: text/plain
+          files: |
+            panel.tar.gz
+            checksum.txt


### PR DESCRIPTION
action-gh-release combined their artifact uploader action with their create release action.  Combine these into a single step.