### PR TITLE
Add default for Automatic Allocation in CreateNode

### DIFF
--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -212,7 +212,7 @@ class CreateNode extends CreateRecord
                                     false => 'success',
                                 ]),
                             Forms\Components\ToggleButtons::make('public')
-                                ->default(config('panel.client_features.allocations.enabled', false))
+                                ->default(true)
                                 ->columnSpan(1)
                                 ->label('Automatic Allocation')->inline()
                                 ->options([

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -212,6 +212,7 @@ class CreateNode extends CreateRecord
                                     false => 'success',
                                 ]),
                             Forms\Components\ToggleButtons::make('public')
+                                ->default(false)
                                 ->columnSpan(1)
                                 ->label('Automatic Allocation')->inline()
                                 ->options([

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -212,7 +212,7 @@ class CreateNode extends CreateRecord
                                     false => 'success',
                                 ]),
                             Forms\Components\ToggleButtons::make('public')
-                                ->default(false)
+                                ->default(config('panel.client_features.allocations.enabled', false))
                                 ->columnSpan(1)
                                 ->label('Automatic Allocation')->inline()
                                 ->options([


### PR DESCRIPTION
Add ->default matching env PANEL_CLIENT_ALLOCATIONS_ENABLED to avoid 500 when creating a node and Automatic Allocation is not set