### PR TITLE
GH-362: Hide container status & server state if nothing is displayed

### DIFF
--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -51,7 +51,7 @@ class EditServer extends EditRecord
                         $details = $service->setServer($server)->getDetails();
 
                         return $details['state'] ?? 'unknown';
-		    })
+                    })
                     ->hidden(fn (string $state) => $state === null)
                     ->options(fn ($state) => collect(ContainerStatus::cases())->filter(fn ($containerStatus) => $containerStatus->value === $state)->mapWithKeys(
                         fn (ContainerStatus $state) => [$state->value => str($state->value)->replace('_', ' ')->ucwords()]
@@ -72,8 +72,8 @@ class EditServer extends EditRecord
                 Forms\Components\ToggleButtons::make('status')
                     ->label('Server State')->inline()->inlineLabel()
                     ->helperText('')
-	                ->hidden(fn (Server $server) => $server->status === null)
-		            ->formatStateUsing(fn ($state) => $state ?? ServerState::Normal)
+                    ->hidden(fn (Server $server) => $server->status === null)
+                    ->formatStateUsing(fn ($state) => $state ?? ServerState::Normal)
                     ->options(fn ($state) => collect(ServerState::cases())->filter(fn ($serverState) => $serverState->value === $state)->mapWithKeys(
                         fn (ServerState $state) => [$state->value => str($state->value)->replace('_', ' ')->ucwords()]
                     ))
@@ -144,7 +144,7 @@ class EditServer extends EditRecord
                                     ->columnSpanFull(),
 
                                 Forms\Components\TextInput::make('uuid')
-                                    ->label("UUID")
+                                    ->label('UUID')
                                     ->hintAction(CopyAction::make())
                                     ->columnSpan([
                                         'default' => 2,

--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -52,7 +52,7 @@ class EditServer extends EditRecord
 
                         return $details['state'] ?? 'unknown';
                     })
-                    ->hidden(fn (string $state) => $state === null)
+                    ->hidden(fn ($state) => $state === null)
                     ->options(fn ($state) => collect(ContainerStatus::cases())->filter(fn ($containerStatus) => $containerStatus->value === $state)->mapWithKeys(
                         fn (ContainerStatus $state) => [$state->value => str($state->value)->replace('_', ' ')->ucwords()]
                     ))

--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -51,7 +51,8 @@ class EditServer extends EditRecord
                         $details = $service->setServer($server)->getDetails();
 
                         return $details['state'] ?? 'unknown';
-                    })
+		    })
+                    ->hidden(fn (string $state) => $state === null)
                     ->options(fn ($state) => collect(ContainerStatus::cases())->filter(fn ($containerStatus) => $containerStatus->value === $state)->mapWithKeys(
                         fn (ContainerStatus $state) => [$state->value => str($state->value)->replace('_', ' ')->ucwords()]
                     ))
@@ -71,7 +72,8 @@ class EditServer extends EditRecord
                 Forms\Components\ToggleButtons::make('status')
                     ->label('Server State')->inline()->inlineLabel()
                     ->helperText('')
-                    ->formatStateUsing(fn ($state) => $state ?? ServerState::Normal)
+	                ->hidden(fn (Server $server) => $server->status === null)
+		            ->formatStateUsing(fn ($state) => $state ?? ServerState::Normal)
                     ->options(fn ($state) => collect(ServerState::cases())->filter(fn ($serverState) => $serverState->value === $state)->mapWithKeys(
                         fn (ServerState $state) => [$state->value => str($state->value)->replace('_', ' ')->ucwords()]
                     ))
@@ -142,6 +144,7 @@ class EditServer extends EditRecord
                                     ->columnSpanFull(),
 
                                 Forms\Components\TextInput::make('uuid')
+                                    ->label("UUID")
                                     ->hintAction(CopyAction::make())
                                     ->columnSpan([
                                         'default' => 2,


### PR DESCRIPTION
Implement new single Server State/Status

> We currently have 2 separate enums for server state and server status.
> Server state refers to our own state such as reinstall, transfer, etc.
> Server status refers to the docker container's status such as running, stopped, etc.
> 
> If the current server state exists, then show it. If it's empty, then we should show the current container status.

> This also includes the labelling in the Edit Server page.

Fixes #362 