### PR TITLE
Add missing "search" translations

### DIFF
--- a/lang/en/search.php
+++ b/lang/en/search.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'validation' => 'Please enter at least three characters to begin searching.',
+    'term' => [
+        'label' => 'Search term',
+        'description' => 'Enter a server name, uuid, or allocation to begin searching.',
+    ],
+];


### PR DESCRIPTION
Fixes #392 

https://github.com/pelican-dev/panel/commit/8f2413dc7eb7cb431035a63e57efbef8fa33244d made the search modal translatable but didn't add the actual translation file for the search.