### PR TITLE
Update OAuth migration

### DIFF
--- a/database/migrations/2024_06_13_120409_add_oauth_column_to_users.php
+++ b/database/migrations/2024_06_13_120409_add_oauth_column_to_users.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->json('oauth')->after('totp_authenticated_at');
+            $table->json('oauth')->nullable()->after('totp_authenticated_at');
         });
     }
 


### PR DESCRIPTION
Make oauth column nullable (JSON fields cannot have default value)
```
INFO  Running migrations.  

  2024_06_13_120409_add_oauth_column_to_users .............................................................................. 1.30ms FAIL

In Connection.php line 813:

  SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL (Connection: sqlite, SQL: alter table "users"   
  add column "oauth" text not null)


In Connection.php line 571:

  SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL
```