### PR TITLE
Make oauth nullable & remove middleware from oauth callback

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,7 +42,7 @@ use App\Notifications\SendPasswordReset as ResetPasswordNotification;
  * @property bool $use_totp
  * @property string|null $totp_secret
  * @property \Illuminate\Support\Carbon|null $totp_authenticated_at
- * @property array $oauth
+ * @property array|null $oauth
  * @property bool $gravatar
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -165,7 +165,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'language' => 'string',
         'use_totp' => 'boolean',
         'totp_secret' => 'nullable|string',
-        'oauth' => 'array',
+        'oauth' => 'array|nullable',
     ];
 
     protected function casts(): array

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -20,7 +20,7 @@ Route::get('/password/reset/{token}', [Auth\LoginController::class, 'index'])->n
 
 // Endpoints for OAuth
 Route::get('/oauth/redirect/{driver}', [Auth\OAuthController::class, 'redirect'])->name('auth.oauth.redirect');
-Route::get('/oauth/callback/{driver}', [Auth\OAuthController::class, 'callback'])->name('auth.oauth.callback');
+Route::get('/oauth/callback/{driver}', [Auth\OAuthController::class, 'callback'])->name('auth.oauth.callback')->withoutMiddleware('guest');
 
 // Apply a throttle to authentication action endpoints, in addition to the
 // recaptcha endpoints to slow down manual attack spammers even more. 🤷‍


### PR DESCRIPTION
Followup fix for #409

Also removes the `guest` middleware so the callback works correctly.