### PR TITLE
Remove hard coded queue name for RunTaskJob

### DIFF
--- a/app/Jobs/Schedule/RunTaskJob.php
+++ b/app/Jobs/Schedule/RunTaskJob.php
@@ -24,7 +24,7 @@ class RunTaskJob extends Job implements ShouldQueue
      */
     public function __construct(public Task $task, public bool $manualRun = false)
     {
-        $this->queue = 'standard';
+
     }
 
     /**


### PR DESCRIPTION
The queue worker only listens on the default queue (called `default`). 