### PR TITLE
Allow empty string in CLI

### DIFF
--- a/app/Traits/Commands/EnvironmentWriterTrait.php
+++ b/app/Traits/Commands/EnvironmentWriterTrait.php
@@ -33,7 +33,7 @@ trait EnvironmentWriterTrait
         $saveContents = file_get_contents($path);
         collect($values)->each(function ($value, $key) use (&$saveContents) {
             $key = strtoupper($key);
-            $saveValue = sprintf('%s=%s', $key, $this->escapeEnvironmentValue($value));
+            $saveValue = sprintf('%s=%s', $key, $this->escapeEnvironmentValue($value ?? ''));
 
             if (preg_match_all('/^' . $key . '=(.*)$/m', $saveContents) < 1) {
                 $saveContents = $saveContents . PHP_EOL . $saveValue;


### PR DESCRIPTION
Update EnvironmentWriterTrait to allow empty string in CLI fixes [Pterodactyl #5108](https://github.com/pterodactyl/panel/issues/5108)