### PR TITLE
Fixes #315 & #453

### DIFF
--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -747,8 +747,7 @@ class EditServer extends EditRecord
             Actions\DeleteAction::make('Delete')
                 ->successRedirectUrl(route('filament.admin.resources.servers.index'))
                 ->color('danger')
-                ->disabled(fn (Server $server) => $server->databases()->count() > 0)
-                ->label(fn (Server $server) => $server->databases()->count() > 0 ? 'Server has a Database' : 'Delete')
+                ->label('Delete')
                 ->after(fn (Server $server) => resolve(ServerDeletionService::class)->handle($server))
                 ->requiresConfirmation(),
             Actions\Action::make('console')


### PR DESCRIPTION
Remove check for databases linked to server before deletion as they get removed as well with [ServerDeletionService](https://github.com/pelican-dev/panel/blob/main/app/Services/Servers/ServerDeletionService.php#L64C55-L64C61)
Here's notAreYouScared's [commit](https://github.com/pelican-dev/panel/commit/85b250d01614f075854e3d09ce85ccef2049e33d#diff-16cfe63641221821898b552395b81b98dac9e23e45265f4435c6bd0e3d4a2309R602) actually fixing the issue on the backend
Fixing #315 and #453 