### PR TITLE
Add Node CPU/Memory Graphs

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\NodeStatistics;
 use App\Models\ActivityLog;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Console\PruneCommand;
@@ -31,6 +32,8 @@ class Kernel extends ConsoleKernel
         // Execute scheduled commands for servers every minute, as if there was a normal cron running.
         $schedule->command(ProcessRunnableCommand::class)->everyMinute()->withoutOverlapping();
         $schedule->command(CleanServiceBackupFilesCommand::class)->daily();
+
+        $schedule->job(new NodeStatistics())->everyFiveSeconds()->withoutOverlapping();
 
         if (config('backups.prune_age')) {
             // Every 30 minutes, run the backup pruning command so that any abandoned backups can be deleted.

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -3,8 +3,6 @@
 namespace App\Filament\Resources\NodeResource\Pages;
 
 use App\Filament\Resources\NodeResource;
-use App\Filament\Resources\NodeResource\Widgets\NodeMemoryChart;
-use App\Filament\Resources\NodeResource\Widgets\NodeStorageChart;
 use App\Models\Node;
 use App\Services\Nodes\NodeUpdateService;
 use Filament\Actions;
@@ -17,6 +15,7 @@ use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
+use Filament\Forms\Components\View;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Filament\Notifications\Notification;
@@ -41,6 +40,15 @@ class EditNode extends EditRecord
                 ->persistTabInQueryString()
                 ->columnSpanFull()
                 ->tabs([
+                    Tab::make('Statistics')
+                        ->label('Statistics')
+                        ->icon('tabler-chart-area-line-filled')
+                        ->columns(6)
+                        ->schema([
+                            View::make('filament.components.node-cpu-chart')->columnSpan(6)->columnStart(0),
+                            View::make('filament.components.node-memory-chart')->columnSpan(3),
+                            View::make('filament.components.node-storage-chart')->columnSpan(3),
+                        ]),
                     Tab::make('Basic Settings')
                         ->icon('tabler-server')
                         ->schema([
@@ -437,16 +445,17 @@ class EditNode extends EditRecord
         ];
     }
 
-    protected function getFooterWidgets(): array
-    {
-        return [
-            NodeStorageChart::class,
-            NodeMemoryChart::class,
-        ];
-    }
-
     protected function afterSave(): void
     {
         $this->fillForm();
+    }
+
+    protected function getColumnSpan()
+    {
+        return null;
+    }
+    protected function getColumnStart()
+    {
+        return null;
     }
 }

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -7,6 +7,7 @@ use App\Models\Node;
 use App\Services\Nodes\NodeUpdateService;
 use Filament\Actions;
 use Filament\Forms;
+use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Tabs;
@@ -40,14 +41,31 @@ class EditNode extends EditRecord
                 ->persistTabInQueryString()
                 ->columnSpanFull()
                 ->tabs([
-                    Tab::make('Statistics')
-                        ->label('Statistics')
+                    Tab::make('')
+                        ->label('Overview')
                         ->icon('tabler-chart-area-line-filled')
                         ->columns(6)
                         ->schema([
-                            View::make('filament.components.node-cpu-chart')->columnSpan(6)->columnStart(0),
+                            Fieldset::make()
+                                ->label('Node Information')
+                                ->columns(4)
+                                ->schema([
+                                    Placeholder::make('')
+                                        ->label('Wings Version')
+                                        ->content(fn (Node $node) => $node->systemInformation()['version']),
+                                    Placeholder::make('')
+                                        ->label('CPU Threads')
+                                        ->content(fn (Node $node) => $node->systemInformation()['cpu_count']),
+                                    Placeholder::make('')
+                                        ->label('Architecture')
+                                        ->content(fn (Node $node) => $node->systemInformation()['architecture']),
+                                    Placeholder::make('')
+                                        ->label('Kernel')
+                                        ->content(fn (Node $node) => $node->systemInformation()['kernel_version']),
+                                ]),
+                            View::make('filament.components.node-cpu-chart')->columnSpan(3),
                             View::make('filament.components.node-memory-chart')->columnSpan(3),
-                            View::make('filament.components.node-storage-chart')->columnSpan(3),
+                            // TODO: Make purdy View::make('filament.components.node-storage-chart')->columnSpan(3),
                         ]),
                     Tab::make('Basic Settings')
                         ->icon('tabler-server')

--- a/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -11,7 +11,7 @@ class NodeCpuChart extends ChartWidget
 {
     protected static ?string $heading = 'CPU';
     protected static ?string $pollingInterval = '5s';
-
+    protected static ?string $maxHeight = '300px';
     public ?Model $record = null;
 
     protected static ?array $options = [
@@ -79,7 +79,7 @@ class NodeCpuChart extends ChartWidget
                     ],
                     'tension' => '0.3',
                     'fill' => true,
-                    'label' => 'CPU Average 1',
+                    'label' => 'Load Average - 1m',
                 ],
                 [
                     'data' => array_column($cpu5, 'cpu5'),
@@ -88,7 +88,7 @@ class NodeCpuChart extends ChartWidget
                     ],
                     'tension' => '0.3',
                     'fill' => true,
-                    'label' => 'CPU Average 5',
+                    'label' => 'Load Average - 5m',
                 ],
                 [
                     'data' => array_column($cpu15, 'cpu15'),
@@ -97,7 +97,7 @@ class NodeCpuChart extends ChartWidget
                     ],
                     'tension' => '0.3',
                     'fill' => true,
-                    'label' => 'CPU Average 5',
+                    'label' => 'Load Average - 15m',
                 ],
             ],
             'labels' => array_column($cpu, 'timestamp'),

--- a/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -19,11 +19,12 @@ class NodeCpuChart extends ChartWidget
     {
         /** @var Node $node */
         $node = $this->record;
+        $threads = $node->systemInformation()['cpu_count'];
 
         $cpu = collect(cache()->get("nodes.$node->id.cpu_percent"))
             ->slice(-10)
             ->map(fn ($value, $key) => [
-                'cpu' => $value,
+                'cpu' => number_format($value * $threads, 2),
                 'timestamp' => Carbon::createFromTimestamp($key, (auth()->user()->timezone ?? 'UTC'))->format('H:i:s'),
             ])
             ->all();
@@ -37,7 +38,6 @@ class NodeCpuChart extends ChartWidget
                     ],
                     'tension' => '0.3',
                     'fill' => true,
-                    'label' => 'Current CPU',
                 ],
             ],
             'labels' => array_column($cpu, 'timestamp'),
@@ -56,7 +56,6 @@ class NodeCpuChart extends ChartWidget
             scales: {
                 y: {
                     min: 0,
-                    max: 100,
                 },
             },
             plugins: {
@@ -72,9 +71,11 @@ class NodeCpuChart extends ChartWidget
     {
         /** @var Node $node */
         $node = $this->record;
+        $threads = $node->systemInformation()['cpu_count'];
 
-        $cpu = collect(cache()->get("nodes.$node->id.cpu_percent"))->last();
+        $cpu = number_format(collect(cache()->get("nodes.$node->id.cpu_percent"))->last() * $threads, 2);
+        $max = number_format($threads * 100) . '%';
 
-        return 'CPU - ' . number_format($cpu, 2) . ' %';
+        return 'CPU - ' . $cpu . '% Of ' . $max;
     }
 }

--- a/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -17,7 +17,7 @@ class NodeCpuChart extends ChartWidget
     protected static ?array $options = [
         'scales' => [
             'y' => [
-                'max' => 100,
+                'suggestedMax' => 25,
                 'min' => 0,
             ],
         ],
@@ -28,9 +28,6 @@ class NodeCpuChart extends ChartWidget
         /** @var Node $node */
         $node = $this->record;
 
-        //        $cpu = ($node->statistics()['cpu_percent'] ?? 0);
-        //        $timestamp = now()->format('H:i:s');
-
         $cpu = collect(cache()->get("nodes.$node->id.cpu_percent"))
             ->slice(-10)
             ->map(fn ($value, $key) => [
@@ -38,29 +35,7 @@ class NodeCpuChart extends ChartWidget
                 'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
             ])
             ->all();
-        $cpu1 = collect(cache()->get("nodes.$node->id.load_average1"))
-            ->slice(-10)
-            ->map(fn ($value, $key) => [
-                'cpu1' => $value,
-                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
-            ])
-            ->all();
-        $cpu5 = collect(cache()->get("nodes.$node->id.load_average5"))
-            ->slice(-10)
-            ->map(fn ($value, $key) => [
-                'cpu5' => $value,
-                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
-            ])
-            ->all();
-        $cpu15 = collect(cache()->get("nodes.$node->id.load_average15"))
-            ->slice(-10)
-            ->map(fn ($value, $key) => [
-                'cpu15' => $value,
-                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
-            ])
-            ->all();
 
-        // Prepare the datasets and labels
         return [
             'datasets' => [
                 [
@@ -71,33 +46,6 @@ class NodeCpuChart extends ChartWidget
                     'tension' => '0.3',
                     'fill' => true,
                     'label' => 'Current CPU',
-                ],
-                [
-                    'data' => array_column($cpu1, 'cpu1'),
-                    'backgroundColor' => [
-                        'rgba(96, 165, 250, 0.2)',
-                    ],
-                    'tension' => '0.3',
-                    'fill' => true,
-                    'label' => 'Load Average - 1m',
-                ],
-                [
-                    'data' => array_column($cpu5, 'cpu5'),
-                    'backgroundColor' => [
-                        'rgba(255, 165, 250, 0.2)',
-                    ],
-                    'tension' => '0.3',
-                    'fill' => true,
-                    'label' => 'Load Average - 5m',
-                ],
-                [
-                    'data' => array_column($cpu15, 'cpu15'),
-                    'backgroundColor' => [
-                        'rgba(255, 165, 250, 0.2)',
-                    ],
-                    'tension' => '0.3',
-                    'fill' => true,
-                    'label' => 'Load Average - 15m',
                 ],
             ],
             'labels' => array_column($cpu, 'timestamp'),

--- a/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -4,24 +4,16 @@ namespace App\Filament\Resources\NodeResource\Widgets;
 
 use App\Models\Node;
 use Carbon\Carbon;
+use Filament\Support\RawJs;
 use Filament\Widgets\ChartWidget;
 use Illuminate\Database\Eloquent\Model;
 
 class NodeCpuChart extends ChartWidget
 {
-    protected static ?string $heading = 'CPU';
     protected static ?string $pollingInterval = '5s';
     protected static ?string $maxHeight = '300px';
-    public ?Model $record = null;
 
-    protected static ?array $options = [
-        'scales' => [
-            'y' => [
-                'suggestedMax' => 25,
-                'min' => 0,
-            ],
-        ],
-    ];
+    public ?Model $record = null;
 
     protected function getData(): array
     {
@@ -41,7 +33,7 @@ class NodeCpuChart extends ChartWidget
                 [
                     'data' => array_column($cpu, 'cpu'),
                     'backgroundColor' => [
-                        'rgba(96, 165, 250, 0.2)',
+                        'rgba(96, 165, 250, 0.3)',
                     ],
                     'tension' => '0.3',
                     'fill' => true,
@@ -55,5 +47,34 @@ class NodeCpuChart extends ChartWidget
     protected function getType(): string
     {
         return 'line';
+    }
+
+    protected function getOptions(): RawJs
+    {
+        return RawJs::make(<<<'JS'
+        {
+            scales: {
+                y: {
+                    min: 0,
+                    max: 100,
+                },
+            },
+            plugins: {
+                legend: {
+                    display: false,
+                }
+            }
+        }
+    JS);
+    }
+
+    public function getHeading(): string
+    {
+        /** @var Node $node */
+        $node = $this->record;
+
+        $cpu = collect(cache()->get("nodes.$node->id.cpu_percent"))->last();
+
+        return 'CPU - ' . number_format($cpu, 2) . ' %';
     }
 }

--- a/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -24,7 +24,7 @@ class NodeCpuChart extends ChartWidget
             ->slice(-10)
             ->map(fn ($value, $key) => [
                 'cpu' => $value,
-                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
+                'timestamp' => Carbon::createFromTimestamp($key, (auth()->user()->timezone ?? 'UTC'))->format('H:i:s'),
             ])
             ->all();
 

--- a/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Resources\NodeResource\Widgets;
+
+use App\Models\Node;
+use Carbon\Carbon;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Database\Eloquent\Model;
+
+class NodeCpuChart extends ChartWidget
+{
+    protected static ?string $heading = 'CPU';
+    protected static ?string $pollingInterval = '5s';
+
+    public ?Model $record = null;
+
+    protected static ?array $options = [
+        'scales' => [
+            'y' => [
+                'suggestedMax' => '0.5',
+            ],
+        ],
+    ];
+
+    protected function getData(): array
+    {
+        /** @var Node $node */
+        $node = $this->record;
+
+        //        $cpu = ($node->statistics()['cpu_percent'] ?? 0);
+        //        $timestamp = now()->format('H:i:s');
+
+        $data = collect(cache()->get("nodes.$node->id.cpu"))
+            ->slice(-10)
+            ->map(fn ($value, $key) => [
+                'cpu' => $value,
+                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
+            ])
+            ->all();
+
+        // Prepare the datasets and labels
+        return [
+            'datasets' => [
+                [
+                    'data' => array_column($data, 'cpu'),
+                    'backgroundColor' => [
+                        'rgba(96, 165, 250, 0.2)',
+                    ],
+                    'tension' => '1',
+                    'fill' => true,
+                ],
+            ],
+            'labels' => array_column($data, 'timestamp'),
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+}

--- a/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -17,7 +17,8 @@ class NodeCpuChart extends ChartWidget
     protected static ?array $options = [
         'scales' => [
             'y' => [
-                'suggestedMax' => '0.5',
+                'max' => 100,
+                'min' => 0,
             ],
         ],
     ];
@@ -30,10 +31,31 @@ class NodeCpuChart extends ChartWidget
         //        $cpu = ($node->statistics()['cpu_percent'] ?? 0);
         //        $timestamp = now()->format('H:i:s');
 
-        $data = collect(cache()->get("nodes.$node->id.cpu"))
+        $cpu = collect(cache()->get("nodes.$node->id.cpu_percent"))
             ->slice(-10)
             ->map(fn ($value, $key) => [
                 'cpu' => $value,
+                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
+            ])
+            ->all();
+        $cpu1 = collect(cache()->get("nodes.$node->id.load_average1"))
+            ->slice(-10)
+            ->map(fn ($value, $key) => [
+                'cpu1' => $value,
+                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
+            ])
+            ->all();
+        $cpu5 = collect(cache()->get("nodes.$node->id.load_average5"))
+            ->slice(-10)
+            ->map(fn ($value, $key) => [
+                'cpu5' => $value,
+                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
+            ])
+            ->all();
+        $cpu15 = collect(cache()->get("nodes.$node->id.load_average15"))
+            ->slice(-10)
+            ->map(fn ($value, $key) => [
+                'cpu15' => $value,
                 'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
             ])
             ->all();
@@ -42,15 +64,43 @@ class NodeCpuChart extends ChartWidget
         return [
             'datasets' => [
                 [
-                    'data' => array_column($data, 'cpu'),
+                    'data' => array_column($cpu, 'cpu'),
                     'backgroundColor' => [
                         'rgba(96, 165, 250, 0.2)',
                     ],
-                    'tension' => '1',
+                    'tension' => '0.3',
                     'fill' => true,
+                    'label' => 'Current CPU',
+                ],
+                [
+                    'data' => array_column($cpu1, 'cpu1'),
+                    'backgroundColor' => [
+                        'rgba(96, 165, 250, 0.2)',
+                    ],
+                    'tension' => '0.3',
+                    'fill' => true,
+                    'label' => 'CPU Average 1',
+                ],
+                [
+                    'data' => array_column($cpu5, 'cpu5'),
+                    'backgroundColor' => [
+                        'rgba(255, 165, 250, 0.2)',
+                    ],
+                    'tension' => '0.3',
+                    'fill' => true,
+                    'label' => 'CPU Average 5',
+                ],
+                [
+                    'data' => array_column($cpu15, 'cpu15'),
+                    'backgroundColor' => [
+                        'rgba(255, 165, 250, 0.2)',
+                    ],
+                    'tension' => '0.3',
+                    'fill' => true,
+                    'label' => 'CPU Average 5',
                 ],
             ],
-            'labels' => array_column($data, 'timestamp'),
+            'labels' => array_column($cpu, 'timestamp'),
         ];
     }
 

--- a/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -4,30 +4,16 @@ namespace App\Filament\Resources\NodeResource\Widgets;
 
 use App\Models\Node;
 use Carbon\Carbon;
+use Filament\Support\RawJs;
 use Filament\Widgets\ChartWidget;
 use Illuminate\Database\Eloquent\Model;
 
 class NodeMemoryChart extends ChartWidget
 {
-    protected static ?string $heading = 'Memory';
     protected static ?string $pollingInterval = '5s';
     protected static ?string $maxHeight = '300px';
 
     public ?Model $record = null;
-
-    protected static ?array $options = [
-        'scales' => [
-            'y' => [
-                'min' => 0,
-            ],
-        ],
-        'tooltips' => [
-            'enabled' => true,
-        ],
-        'plugins' => [
-            'datalabels' => [],
-        ],
-    ];
 
     protected function getData(): array
     {
@@ -38,8 +24,7 @@ class NodeMemoryChart extends ChartWidget
             ->map(fn ($value, $key) => [
                 'memory' => $value / 1024 / 1024 / 1024,
                 'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
-            ]
-            )
+            ])
             ->all();
 
         return [
@@ -47,7 +32,7 @@ class NodeMemoryChart extends ChartWidget
                 [
                     'data' => array_column($memUsed, 'memory'),
                     'backgroundColor' => [
-                        'rgba(96, 165, 250, 0.2)',
+                        'rgba(96, 165, 250, 0.3)',
                     ],
                     'tension' => '0.3',
                     'fill' => true,
@@ -64,4 +49,32 @@ class NodeMemoryChart extends ChartWidget
         return 'line';
     }
 
+    protected function getOptions(): RawJs
+    {
+        return RawJs::make(<<<'JS'
+        {
+            scales: {
+                y: {
+                    min: 0,
+                },
+            },
+            plugins: {
+                legend: {
+                    display: false,
+                }
+            }
+        }
+    JS);
+    }
+
+    public function getHeading(): string
+    {
+        /** @var Node $node */
+        $node = $this->record;
+
+        $latestMemoryUsed = collect(cache()->get("nodes.$node->id.memory_used"))->last();
+        $totalMemory = collect(cache()->get("nodes.$node->id.memory_total"))->last();
+
+        return 'Memory - ' . number_format($latestMemoryUsed / 1024 / 1024 / 1024, 2) . ' GB of ' . number_format($totalMemory / 1024 / 1024 / 1024). ' GB';
+    }
 }

--- a/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -36,7 +36,6 @@ class NodeMemoryChart extends ChartWidget
                     ],
                     'tension' => '0.3',
                     'fill' => true,
-                    'label' => 'Memory Usage',
                 ],
             ],
             'labels' => array_column($memUsed, 'timestamp'),

--- a/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -44,10 +44,11 @@ class NodeMemoryChart extends ChartWidget
         $used = ($node->statistics()['memory_used'] ?? 0) / 1024 / 1024 / 1024;
         $unused = $total - $used;
 
+        //        dd($total, $used);
+
         return [
             'datasets' => [
                 [
-                    'label' => 'Data Cool',
                     'data' => [$used, $unused],
                     'backgroundColor' => [
                         'rgb(255, 99, 132)',
@@ -55,7 +56,6 @@ class NodeMemoryChart extends ChartWidget
                         'rgb(255, 205, 86)',
                     ],
                 ],
-                // 'backgroundColor' => [],
             ],
             'labels' => ['Used', 'Unused'],
         ];

--- a/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -3,35 +3,29 @@
 namespace App\Filament\Resources\NodeResource\Widgets;
 
 use App\Models\Node;
+use Carbon\Carbon;
 use Filament\Widgets\ChartWidget;
 use Illuminate\Database\Eloquent\Model;
 
 class NodeMemoryChart extends ChartWidget
 {
     protected static ?string $heading = 'Memory';
-    protected static ?string $pollingInterval = '60s';
+    protected static ?string $pollingInterval = '5s';
     protected static ?string $maxHeight = '300px';
 
     public ?Model $record = null;
 
     protected static ?array $options = [
         'scales' => [
-            'x' => [
-                'grid' => [
-                    'display' => false,
-                ],
-                'ticks' => [
-                    'display' => false,
-                ],
-            ],
             'y' => [
-                'grid' => [
-                    'display' => false,
-                ],
-                'ticks' => [
-                    'display' => false,
-                ],
+                'min' => 0,
             ],
+        ],
+        'tooltips' => [
+            'enabled' => true,
+        ],
+        'plugins' => [
+            'datalabels' => [],
         ],
     ];
 
@@ -40,29 +34,50 @@ class NodeMemoryChart extends ChartWidget
         /** @var Node $node */
         $node = $this->record;
 
-        $total = ($node->statistics()['memory_total'] ?? 0) / 1024 / 1024 / 1024;
-        $used = ($node->statistics()['memory_used'] ?? 0) / 1024 / 1024 / 1024;
-        $unused = $total - $used;
+        $memUsed = collect(cache()->get("nodes.$node->id.memory_used"))->slice(-10)
+            ->map(function ($value, $key) {
+                $unit = 1024;
+                $decimals = 2;
 
-        //        dd($total, $used);
+                if ($value < 1) {
+                    return '0 Bytes';
+                }
+
+                $decimals = floor(max(0, $decimals));
+                $i = floor(log($value, $unit));
+                $result = number_format($value / pow($unit, $i), $decimals, '.', '');
+
+                $units = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB'];
+                $output = $result . ' ' . $units[$i];
+
+                return [
+                    'memory' => $value / 1024 / 1024 / 1024,
+                    'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
+                ];
+
+            })
+            ->all();
 
         return [
             'datasets' => [
                 [
-                    'data' => [$used, $unused],
+                    'data' => array_column($memUsed, 'memory'),
                     'backgroundColor' => [
-                        'rgb(255, 99, 132)',
-                        'rgb(54, 162, 235)',
-                        'rgb(255, 205, 86)',
+                        'rgba(96, 165, 250, 0.2)',
                     ],
+                    'tension' => '0.3',
+                    'fill' => true,
+                    'label' => 'Memory Usage',
+                    'datalabels' => true,
                 ],
             ],
-            'labels' => ['Used', 'Unused'],
+            'labels' => array_column($memUsed, 'timestamp'),
         ];
     }
 
     protected function getType(): string
     {
-        return 'pie';
+        return 'line';
     }
+
 }

--- a/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -9,8 +9,8 @@ use Illuminate\Database\Eloquent\Model;
 class NodeMemoryChart extends ChartWidget
 {
     protected static ?string $heading = 'Memory';
-
     protected static ?string $pollingInterval = '60s';
+    protected static ?string $maxHeight = '300px';
 
     public ?Model $record = null;
 

--- a/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -22,7 +22,7 @@ class NodeMemoryChart extends ChartWidget
 
         $memUsed = collect(cache()->get("nodes.$node->id.memory_used"))->slice(-10)
             ->map(fn ($value, $key) => [
-                'memory' => config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1.048576,
+                'memory' => config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1000 / 1000 / 1000,
                 'timestamp' => Carbon::createFromTimestamp($key, (auth()->user()->timezone ?? 'UTC'))->format('H:i:s'),
             ])
             ->all();

--- a/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -35,27 +35,11 @@ class NodeMemoryChart extends ChartWidget
         $node = $this->record;
 
         $memUsed = collect(cache()->get("nodes.$node->id.memory_used"))->slice(-10)
-            ->map(function ($value, $key) {
-                $unit = 1024;
-                $decimals = 2;
-
-                if ($value < 1) {
-                    return '0 Bytes';
-                }
-
-                $decimals = floor(max(0, $decimals));
-                $i = floor(log($value, $unit));
-                $result = number_format($value / pow($unit, $i), $decimals, '.', '');
-
-                $units = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB'];
-                $output = $result . ' ' . $units[$i];
-
-                return [
-                    'memory' => $value / 1024 / 1024 / 1024,
-                    'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
-                ];
-
-            })
+            ->map(fn ($value, $key) => [
+                'memory' => $value / 1024 / 1024 / 1024,
+                'timestamp' => Carbon::createFromTimestamp($key)->format('H:i:s'),
+            ]
+            )
             ->all();
 
         return [

--- a/app/Filament/Resources/NodeResource/Widgets/NodeStorageChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeStorageChart.php
@@ -9,8 +9,8 @@ use Illuminate\Database\Eloquent\Model;
 class NodeStorageChart extends ChartWidget
 {
     protected static ?string $heading = 'Storage';
-
     protected static ?string $pollingInterval = '60s';
+    protected static ?string $maxHeight = '300px';
 
     public ?Model $record = null;
 

--- a/app/Filament/Resources/NodeResource/Widgets/NodeStorageChart.php
+++ b/app/Filament/Resources/NodeResource/Widgets/NodeStorageChart.php
@@ -47,7 +47,6 @@ class NodeStorageChart extends ChartWidget
         return [
             'datasets' => [
                 [
-                    'label' => 'Data Cool',
                     'data' => [$used, $unused],
                     'backgroundColor' => [
                         'rgb(255, 99, 132)',
@@ -55,7 +54,6 @@ class NodeStorageChart extends ChartWidget
                         'rgb(255, 205, 86)',
                     ],
                 ],
-                // 'backgroundColor' => [],
             ],
             'labels' => ['Used', 'Unused'],
         ];

--- a/app/Jobs/NodeStatistics.php
+++ b/app/Jobs/NodeStatistics.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Node;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class NodeStatistics implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        foreach (Node::all() as $node) {
+            $key = "nodes.$node->id.cpu";
+            $stats = $node->statistics();
+            $data = cache()->get($key, []);
+
+            $data[now()->getTimestamp()] = $stats['cpu_percent'] ?? 0;
+
+            cache()->put($key, $data, now()->addMinute());
+        }
+    }
+}

--- a/app/Jobs/NodeStatistics.php
+++ b/app/Jobs/NodeStatistics.php
@@ -27,13 +27,20 @@ class NodeStatistics implements ShouldQueue
     public function handle(): void
     {
         foreach (Node::all() as $node) {
-            $key = "nodes.$node->id.cpu";
             $stats = $node->statistics();
-            $data = cache()->get($key, []);
+            $timestamp = now()->getTimestamp();
 
-            $data[now()->getTimestamp()] = $stats['cpu_percent'] ?? 0;
+            foreach ($stats as $key => $value) {
+                $cacheKey = "nodes.{$node->id}.$key";
+                $data = cache()->get($cacheKey, []);
 
-            cache()->put($key, $data, now()->addMinute());
+                // Add current timestamp and value to the data array
+                $data[$timestamp] = $value;
+
+                // Update the cache with the new data, expires in 1 minute
+                cache()->put($cacheKey, $data, now()->addMinute());
+            }
         }
     }
+
 }

--- a/resources/views/filament/components/node-cpu-chart.blade.php
+++ b/resources/views/filament/components/node-cpu-chart.blade.php
@@ -1,0 +1,3 @@
+<x-filament::widget>
+        @livewire(\App\Filament\Resources\NodeResource\Widgets\NodeCpuChart::class, ['record'=> $getRecord()])
+</x-filament::widget>

--- a/resources/views/filament/components/node-memory-chart.blade.php
+++ b/resources/views/filament/components/node-memory-chart.blade.php
@@ -1,0 +1,3 @@
+<x-filament::widget>
+        @livewire(\App\Filament\Resources\NodeResource\Widgets\NodeMemoryChart::class, ['record'=> $getRecord()])
+</x-filament::widget>

--- a/resources/views/filament/components/node-storage-chart.blade.php
+++ b/resources/views/filament/components/node-storage-chart.blade.php
@@ -1,0 +1,3 @@
+<x-filament::widget>
+        @livewire(\App\Filament\Resources\NodeResource\Widgets\NodeStorageChart::class, ['record'=> $getRecord()])
+</x-filament::widget>


### PR DESCRIPTION
Adds an overview tab to EditNode, Shows basic system information, and current host node cpu/memory usage, updated every 5 seconds 

![image](https://github.com/pelican-dev/panel/assets/1757840/56db4a65-3b10-4fe8-b7f3-e6be1dc89504)
