### PR TITLE
Fix default timestamp for activity logs

### DIFF
--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -141,7 +141,7 @@ class ActivityLog extends Model
         parent::boot();
 
         static::creating(function (self $model) {
-            $model->timestamp = Carbon::now()->toDateTimeString();
+            $model->timestamp = Carbon::now();
         });
 
         static::created(function (self $model) {

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -140,6 +140,10 @@ class ActivityLog extends Model
     {
         parent::boot();
 
+        static::creating(function (self $model) {
+            $model->timestamp = Carbon::now()->toDateTimeString();
+        });
+
         static::created(function (self $model) {
             Event::dispatch(new ActivityLogged($model));
         });

--- a/database/migrations/2024_07_08_112948_fix-activity-log-timestamp-default.php
+++ b/database/migrations/2024_07_08_112948_fix-activity-log-timestamp-default.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->timestamp('timestamp')->default(null)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->timestamp('timestamp')->useCurrent()->change();
+        });
+    }
+};


### PR DESCRIPTION
The `timestamp` column for activity logs [uses `useCurrent`](https://github.com/pelican-dev/panel/blob/main/database/migrations/2022_05_28_135717_create_activity_logs_table.php#L22) which sets the default column value to `CURRENT_TIMESTAMP`. But this uses the database timezone.
This causes the timezone to be "added twice" on the frontend.

Example with `Europe/Berlin`:
![grafik](https://github.com/pelican-dev/panel/assets/8203120/d3fc5999-647a-4358-a86a-a1e1d71bdd0a)
![grafik](https://github.com/pelican-dev/panel/assets/8203120/11488441-398a-4076-99f2-34e26910f7a7)

This PR removes the default and sets the timestamp to `Carbon::now()` when the model is created.