### PR TITLE
Correctly handle X-Forwarded-For and retrieve the real IP (#473)

### DIFF
--- a/app/Http/Middleware/ProxyHandler.php
+++ b/app/Http/Middleware/ProxyHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Foundation\Application;
+
+class ProxyHandler
+{
+    /**
+     * Handle an incoming request and set the request IP to X-Forwarded-For if exists.
+    */
+    public function handle(Request $request, \Closure $next)
+    {
+        if ($request->hasHeader('X-Forwarded-For')) {
+            $forwarded = $request->header('X-Forwarded-For');
+            $client = trim(explode(',', $forwarded)[0]);
+            $request->server->set('REMOTE_ADDR', $client);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ProxyHandler.php
+++ b/app/Http/Middleware/ProxyHandler.php
@@ -3,13 +3,12 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
-use Illuminate\Foundation\Application;
 
 class ProxyHandler
 {
     /**
-     * Handle an incoming request and set the request IP to X-Forwarded-For if exists.
-    */
+     * Handle an incoming request and set the request IP to X-Forwarded-For if it exists.
+     */
     public function handle(Request $request, \Closure $next)
     {
         if ($request->hasHeader('X-Forwarded-For')) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,7 +15,10 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->redirectGuestsTo(fn () => route('auth.login'));
 
-        $middleware->web(\App\Http\Middleware\LanguageMiddleware::class);
+        $middleware->web([
+            \App\Http\Middleware\LanguageMiddleware::class,
+            \App\Http\Middleware\ProxyHandler::class,
+        ]);
 
         $middleware->api([
             \App\Http\Middleware\EnsureStatefulRequests::class,


### PR DESCRIPTION
This will correctly show the user's IP if the web server is configured to do so properly and is behind a service such as Cloudflare. Tested with Caddy built with [this](https://caddyserver.com/docs/modules/http.ip_sources.cloudflare) module. Works on my instance, but would love further testing by someone. The same should be done for wings, but I am not good at Go so someone else gets that task.