### PR TITLE
Make jest tests pass again

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,28 @@ on:
       - '**'
 
 jobs:
+  jest:
+    name: Jest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn run test
   pint:
     name: Pint
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,5 +24,5 @@ module.exports = {
         '.*\\.[t|j]sx$': 'babel-jest',
         '.*\\.ts$': 'ts-jest',
     },
-    testPathIgnorePatterns: ['/node_modules/'],
+    testPathIgnorePatterns: ['/node_modules/','/vendor/'],
 };


### PR DESCRIPTION
- [x] Make jest tests pass again by adding vendor to exclude
- [x] Add jest to workflow

Before
```
yarn run test
yarn run v1.22.22
$ jest
 PASS  resources/scripts/lib/formatters.spec.ts
 PASS  resources/scripts/lib/strings.spec.ts
 PASS  resources/scripts/lib/helpers.spec.ts
 PASS  resources/scripts/lib/objects.spec.ts
 FAIL  vendor/livewire/livewire/src/Features/SupportScriptsAndAssets/test.js
  ● Test suite failed to run

    The error below may be caused by using the wrong test environment, see https://jestjs.io/docs/configuration#testenvironment-string.
    Consider using the "jsdom" test environment.
    
    ReferenceError: document is not defined

      1 |
    > 2 | document.querySelector('[dusk="foo"]').textContent = 'evaluated'
        | ^
      3 |

      at Object.<anonymous> (vendor/livewire/livewire/src/Features/SupportScriptsAndAssets/test.js:2:1)
      at TestScheduler.scheduleTests (node_modules/@jest/core/build/TestScheduler.js:317:13)
      at runJest (node_modules/@jest/core/build/runJest.js:407:19)

Test Suites: 1 failed, 4 passed, 5 total
Tests:       46 passed, 46 total
Snapshots:   0 total
Time:        0.655 s, estimated 1 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
After
```
yarn run test
yarn run v1.22.22
$ jest
 PASS  resources/scripts/lib/formatters.spec.ts
 PASS  resources/scripts/lib/helpers.spec.ts
 PASS  resources/scripts/lib/strings.spec.ts
 PASS  resources/scripts/lib/objects.spec.ts

Test Suites: 4 passed, 4 total
Tests:       46 passed, 46 total
Snapshots:   0 total
Time:        0.693 s, estimated 1 s
Ran all test suites.
Done in 1.54s.
```