### PR TITLE
Increase guzzle timeout when running tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
       DB_HOST: 127.0.0.1
       DB_DATABASE: testing
       DB_USERNAME: root
+      GUZZLE_TIMEOUT: 60
+      GUZZLE_CONNECT_TIMEOUT: 60
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4
@@ -113,6 +115,8 @@ jobs:
       DB_HOST: 127.0.0.1
       DB_DATABASE: testing
       DB_USERNAME: root
+      GUZZLE_TIMEOUT: 60
+      GUZZLE_CONNECT_TIMEOUT: 60
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4
@@ -173,6 +177,8 @@ jobs:
       QUEUE_CONNECTION: sync
       DB_CONNECTION: sqlite
       DB_DATABASE: testing.sqlite
+      GUZZLE_TIMEOUT: 60
+      GUZZLE_CONNECT_TIMEOUT: 60
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4

--- a/app/Services/Helpers/SoftwareVersionService.php
+++ b/app/Services/Helpers/SoftwareVersionService.php
@@ -4,7 +4,7 @@ namespace App\Services\Helpers;
 
 use GuzzleHttp\Client;
 use Carbon\CarbonImmutable;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
@@ -110,7 +110,7 @@ class SoftwareVersionService
                     $wingsData = json_decode($response->getBody(), true);
                     $versionData['daemon'] = trim($wingsData['tag_name'], 'v');
                 }
-            } catch (ClientException $e) {
+            } catch (GuzzleException $e) {
             }
 
             $versionData['discord'] = 'https://pelican.dev/discord';


### PR DESCRIPTION
Some tests sporadically fail because the version check request times out. Increasing the timeouts during tests should prevent that.
Also changed the try catch exception from `ClientException` to `GuzzleException`.

![grafik](https://github.com/user-attachments/assets/f9925b30-460f-4cdd-9ed7-56b7fc9b86df)
