### PR TITLE
Fix `PORT_FLOOR` check and `CIDR_MAX_BITS` in AssignmentService

### DIFF
--- a/app/Services/Allocations/AssignmentService.php
+++ b/app/Services/Allocations/AssignmentService.php
@@ -14,7 +14,7 @@ use App\Exceptions\Service\Allocation\TooManyPortsInRangeException;
 
 class AssignmentService
 {
-    public const CIDR_MAX_BITS = 27;
+    public const CIDR_MAX_BITS = 25;
     public const CIDR_MIN_BITS = 32;
     public const PORT_FLOOR = 1024;
     public const PORT_CEIL = 65535;

--- a/app/Services/Allocations/AssignmentService.php
+++ b/app/Services/Allocations/AssignmentService.php
@@ -74,7 +74,7 @@ class AssignmentService
                         throw new TooManyPortsInRangeException();
                     }
 
-                    if ((int) $matches[1] <= self::PORT_FLOOR || (int) $matches[2] > self::PORT_CEIL) {
+                    if ((int) $matches[1] < self::PORT_FLOOR || (int) $matches[2] > self::PORT_CEIL) {
                         throw new PortOutOfRangeException();
                     }
 
@@ -88,7 +88,7 @@ class AssignmentService
                         ];
                     }
                 } else {
-                    if ((int) $port <= self::PORT_FLOOR || (int) $port > self::PORT_CEIL) {
+                    if ((int) $port < self::PORT_FLOOR || (int) $port > self::PORT_CEIL) {
                         throw new PortOutOfRangeException();
                     }
 

--- a/lang/en/exceptions.php
+++ b/lang/en/exceptions.php
@@ -11,7 +11,7 @@ return [
         'too_many_ports' => 'Adding more than 1000 ports in a single range at once is not supported.',
         'invalid_mapping' => 'The mapping provided for :port was invalid and could not be processed.',
         'cidr_out_of_range' => 'CIDR notation only allows masks between /25 and /32.',
-        'port_out_of_range' => 'Ports in an allocation must be greater than 1024 and less than or equal to 65535.',
+        'port_out_of_range' => 'Ports in an allocation must be greater than or equal to 1024 and less than or equal to 65535.',
     ],
     'egg' => [
         'delete_has_servers' => 'An Egg with active servers attached to it cannot be deleted from the Panel.',


### PR DESCRIPTION
Ports needs to be "greater than or equal to 1024". 1024 itself works fine:
![image](https://github.com/user-attachments/assets/07b39184-26c7-43aa-9671-a419b8deb50b)

Also fixes the max CIDR mask, ref https://github.com/pterodactyl/panel/pull/5111.