### PR TITLE
Fix update egg from url

### DIFF
--- a/app/Filament/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Resources/EggResource/Pages/EditEgg.php
@@ -249,9 +249,9 @@ class EditEgg extends EditRecord
                             Tab::make('From URL')
                                 ->icon('tabler-world-upload')
                                 ->schema([
-                                    TextInput::make('update_url')
+                                    TextInput::make('url')
                                         ->label('URL')
-                                        ->formatStateUsing(fn (Egg $egg): string => $egg->update_url)
+                                        ->default(fn (Egg $egg): string => $egg->update_url)
                                         ->hint('Link to the egg file (eg. minecraft.json)')
                                         ->url(),
                                 ]),


### PR DESCRIPTION
https://github.com/pelican-dev/panel/commit/160ea1ed50231db4719f604d46904b0c4ddfcd14 changed the field name to `update_url` which broke the updating.