### PR TITLE
Ability to create allocations on EditServer page

### DIFF
--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -124,7 +124,8 @@ class EditServer extends EditRecord
                                         'md' => 2,
                                         'lg' => 3,
                                     ])
-                                    ->readOnly(),
+                                    ->readOnly()
+                                    ->dehydrated(false),
                                 Forms\Components\TextInput::make('uuid_short')
                                     ->label('Short UUID')
                                     ->hintAction(CopyAction::make())
@@ -134,7 +135,8 @@ class EditServer extends EditRecord
                                         'md' => 2,
                                         'lg' => 3,
                                     ])
-                                    ->readOnly(),
+                                    ->readOnly()
+                                    ->dehydrated(false),
                                 Forms\Components\TextInput::make('external_id')
                                     ->label('External ID')
                                     ->columnSpan([

--- a/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
@@ -67,6 +67,7 @@ class AllocationsRelationManager extends RelationManager
             ])
             ->headerActions([
                 Tables\Actions\CreateAction::make()->label('Create Allocation')
+                    ->createAnother(false)
                     ->form(fn () => [
                         TextInput::make('allocation_ip')
                             ->datalist($this->getOwnerRecord()->node->ipAddresses())
@@ -145,6 +146,7 @@ class AllocationsRelationManager extends RelationManager
                     ->action(fn (array $data) => resolve(AssignmentService::class)->handle($this->getOwnerRecord()->node, $data, $this->getOwnerRecord())),
                 Tables\Actions\AssociateAction::make()
                     ->multiple()
+                    ->associateAnother(false)
                     ->preloadRecordSelect()
                     ->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo($this->getOwnerRecord()->node))
                     ->label('Add Allocation'),

--- a/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
@@ -4,11 +4,15 @@ namespace App\Filament\Resources\ServerResource\RelationManagers;
 
 use App\Models\Allocation;
 use App\Models\Server;
-use Filament\Forms;
+use App\Services\Allocations\AssignmentService;
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Set;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
 
 /**
  * @method Server getOwnerRecord()
@@ -21,7 +25,7 @@ class AllocationsRelationManager extends RelationManager
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('ip')
+                TextInput::make('ip')
                     ->required()
                     ->maxLength(255),
             ]);
@@ -62,7 +66,83 @@ class AllocationsRelationManager extends RelationManager
                     ->label(fn (Allocation $allocation) => $allocation->id === $this->getOwnerRecord()->allocation_id ? '' : 'Make Primary'),
             ])
             ->headerActions([
-                //TODO Tables\Actions\CreateAction::make()->label('Create Allocation'),
+                Tables\Actions\CreateAction::make()->label('Create Allocation')
+                    ->form(fn () => [
+                        TextInput::make('allocation_ip')
+                            ->datalist($this->getOwnerRecord()->node->ipAddresses())
+                            ->label('IP Address')
+                            ->inlineLabel()
+                            ->ipv4()
+                            ->helperText("Usually your machine's public IP unless you are port forwarding.")
+                            ->required(),
+                        TextInput::make('allocation_alias')
+                            ->label('Alias')
+                            ->inlineLabel()
+                            ->default(null)
+                            ->helperText('Optional display name to help you remember what these are.')
+                            ->required(false),
+                        TagsInput::make('allocation_ports')
+                            ->placeholder('Examples: 27015, 27017-27019')
+                            ->helperText(new HtmlString('
+                                These are the ports that users can connect to this Server through.
+                                <br />
+                                You would have to port forward these on your home network.
+                            '))
+                            ->label('Ports')
+                            ->inlineLabel()
+                            ->live()
+                            ->afterStateUpdated(function ($state, Set $set) {
+                                $ports = collect();
+                                $update = false;
+                                foreach ($state as $portEntry) {
+                                    if (!str_contains($portEntry, '-')) {
+                                        if (is_numeric($portEntry)) {
+                                            $ports->push((int) $portEntry);
+
+                                            continue;
+                                        }
+
+                                        // Do not add non numerical ports
+                                        $update = true;
+
+                                        continue;
+                                    }
+
+                                    $update = true;
+                                    [$start, $end] = explode('-', $portEntry);
+                                    if (!is_numeric($start) || !is_numeric($end)) {
+                                        continue;
+                                    }
+
+                                    $start = max((int) $start, 0);
+                                    $end = min((int) $end, 2 ** 16 - 1);
+                                    foreach (range($start, $end) as $i) {
+                                        $ports->push($i);
+                                    }
+                                }
+
+                                $uniquePorts = $ports->unique()->values();
+                                if ($ports->count() > $uniquePorts->count()) {
+                                    $update = true;
+                                    $ports = $uniquePorts;
+                                }
+
+                                $sortedPorts = $ports->sort()->values();
+                                if ($sortedPorts->all() !== $ports->all()) {
+                                    $update = true;
+                                    $ports = $sortedPorts;
+                                }
+
+                                $ports = $ports->filter(fn ($port) => $port > 1024 && $port < 65535)->values();
+
+                                if ($update) {
+                                    $set('allocation_ports', $ports->all());
+                                }
+                            })
+                            ->splitKeys(['Tab', ' ', ','])
+                            ->required(),
+                    ])
+                    ->action(fn (array $data) => resolve(AssignmentService::class)->handle($this->getOwnerRecord()->node, $data, $this->getOwnerRecord())),
                 Tables\Actions\AssociateAction::make()
                     ->multiple()
                     ->preloadRecordSelect()

--- a/app/Filament/Resources/UserResource/Pages/EditProfile.php
+++ b/app/Filament/Resources/UserResource/Pages/EditProfile.php
@@ -53,6 +53,7 @@ class EditProfile extends \Filament\Pages\Auth\EditProfile
                                             ->label(trans('strings.username'))
                                             ->disabled()
                                             ->readOnly()
+                                            ->dehydrated(false)
                                             ->maxLength(255)
                                             ->unique(ignoreRecord: true)
                                             ->autofocus(),
@@ -119,6 +120,7 @@ class EditProfile extends \Filament\Pages\Auth\EditProfile
                                                     ->hidden(fn () => !cache()->get("users.{$this->getUser()->id}.2fa.tokens"))
                                                     ->rows(10)
                                                     ->readOnly()
+                                                    ->dehydrated(false)
                                                     ->formatStateUsing(fn () => cache()->get("users.{$this->getUser()->id}.2fa.tokens"))
                                                     ->helperText('These will not be shown again!')
                                                     ->label('Backup Tokens:'),

--- a/app/Services/Allocations/AssignmentService.php
+++ b/app/Services/Allocations/AssignmentService.php
@@ -5,6 +5,7 @@ namespace App\Services\Allocations;
 use App\Models\Allocation;
 use IPTools\Network;
 use App\Models\Node;
+use App\Models\Server;
 use Illuminate\Database\ConnectionInterface;
 use App\Exceptions\DisplayException;
 use App\Exceptions\Service\Allocation\CidrOutOfRangeException;
@@ -37,7 +38,7 @@ class AssignmentService
      * @throws \App\Exceptions\Service\Allocation\PortOutOfRangeException
      * @throws \App\Exceptions\Service\Allocation\TooManyPortsInRangeException
      */
-    public function handle(Node $node, array $data): array
+    public function handle(Node $node, array $data, Server $server = null): array
     {
         $explode = explode('/', $data['allocation_ip']);
         if (count($explode) !== 1) {
@@ -84,7 +85,7 @@ class AssignmentService
                             'ip' => $ip->__toString(),
                             'port' => (int) $unit,
                             'ip_alias' => array_get($data, 'allocation_alias'),
-                            'server_id' => null,
+                            'server_id' => $server->id ?? null,
                         ];
                     }
                 } else {
@@ -97,7 +98,7 @@ class AssignmentService
                         'ip' => $ip->__toString(),
                         'port' => (int) $port,
                         'ip_alias' => array_get($data, 'allocation_alias'),
-                        'server_id' => null,
+                        'server_id' => $server->id ?? null,
                     ];
                 }
 


### PR DESCRIPTION
- [x] Ability to create allocations on EditServer page
- [x] Ability to assign Allocation to Server on creation (AssignmentService)

- [x] Add `->dehydrated(false)` to readOnly fields so user edited ones do not change on the server as [recommended](https://filamentphp.com/docs/3.x/forms/fields/text-input#making-the-field-read-only)