### PR TITLE
mysql and mariadb client command for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN rm /usr/local/etc/php-fpm.conf \
     && sed -i s/ssl_session_cache/#ssl_session_cache/g /etc/nginx/nginx.conf \
     && mkdir -p /var/run/php /var/run/nginx
 
+RUN apk add mariadb-client mysql-client
+
 COPY .github/docker/default.conf /etc/nginx/http.d/default.conf
 COPY .github/docker/www.conf /usr/local/etc/php-fpm.conf
 COPY .github/docker/supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
Upon building the dockerfile there is a slight issue then using these env var
```bash
DB_CONNECTION=mariadb
or
DB_CONNECTION=mysql
```

will result a failed command the container or the app will fail to start up, I have created a quick fix that add these command as client only