### PR TITLE
Fix #524 Make default favicon path absolute to avoid 404 on admin

### DIFF
--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -92,7 +92,7 @@ class Settings extends Page implements HasForms
                 ->hintIcon('tabler-question-mark')
                 ->hintIconTooltip('Favicons should be placed in the public folder, located in the root panel directory.')
                 ->required()
-                ->default(env('APP_FAVICON', './pelican.ico')),
+                ->default(env('APP_FAVICON', '/pelican.ico')),
             Toggle::make('APP_DEBUG')
                 ->label('Enable Debug Mode?')
                 ->inline(false)

--- a/config/app.php
+++ b/config/app.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Facade;
 return [
 
     'name' => env('APP_NAME', 'Pelican'),
-    'favicon' => env('APP_FAVICON', './pelican.ico'),
+    'favicon' => env('APP_FAVICON', '/pelican.ico'),
 
     'version' => 'canary',
 


### PR DESCRIPTION
Remove `.` to make the path absolute instead of relative
Just like everywhere else
https://github.com/pelican-dev/panel/blob/2e094605e9a300273fb97032c86b70703c06bb2d/app/Providers/Filament/AdminPanelProvider.php#L41
https://github.com/pelican-dev/panel/blob/2e094605e9a300273fb97032c86b70703c06bb2d/resources/views/templates/wrapper.blade.php#L12
https://github.com/pelican-dev/panel/blob/2e094605e9a300273fb97032c86b70703c06bb2d/resources/views/layouts/admin.blade.php#L10
>why would you want an other icon specific to the admin side ?