### PR TITLE
remove 'guest' middleware to enable oauth account linking

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -19,7 +19,7 @@ Route::get('/password', [Auth\LoginController::class, 'index'])->name('auth.forg
 Route::get('/password/reset/{token}', [Auth\LoginController::class, 'index'])->name('auth.reset');
 
 // Endpoints for OAuth
-Route::get('/oauth/redirect/{driver}', [Auth\OAuthController::class, 'redirect'])->name('auth.oauth.redirect');
+Route::get('/oauth/redirect/{driver}', [Auth\OAuthController::class, 'redirect'])->name('auth.oauth.redirect')->withoutMiddleware('guest');
 Route::get('/oauth/callback/{driver}', [Auth\OAuthController::class, 'callback'])->name('auth.oauth.callback')->withoutMiddleware('guest');
 
 // Apply a throttle to authentication action endpoints, in addition to the


### PR DESCRIPTION
The ``guest`` middleware did not allow for authenticated users to call the /auth/oauth/redirect endpoint resulting in not being able to link an oauth account to yours.