### PR TITLE
Replace `fonts.googleapis.com` with `fonts.bunny.net`

### DIFF
--- a/public/themes/panel/css/terminal.css
+++ b/public/themes/panel/css/terminal.css
@@ -1,5 +1,5 @@
 /*Design for Terminal*/
-@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
+@import url('https://fonts.bunny.net/css?family=Source+Code+Pro');
 
 #terminal-body {
     background: rgb(26, 26, 26);

--- a/resources/views/templates/wrapper.blade.php
+++ b/resources/views/templates/wrapper.blade.php
@@ -27,8 +27,8 @@
             @endif
         @show
         <style>
-            @import url('//fonts.googleapis.com/css?family=Rubik:300,400,500&display=swap');
-            @import url('//fonts.googleapis.com/css?family=IBM+Plex+Mono|IBM+Plex+Sans:500&display=swap');
+            @import url('//fonts.bunny.net/css?family=Rubik:300,400,500&display=swap');
+            @import url('//fonts.bunny.net/css?family=IBM+Plex+Mono|IBM+Plex+Sans:500&display=swap');
         </style>
 
         @yield('assets')


### PR DESCRIPTION
*happy GDPR noises*

Filament already uses `fonts.bunny.net` for the fonts.