### PR TITLE
Remove old queue worker args in docker supervisord

### DIFF
--- a/.github/docker/supervisord.conf
+++ b/.github/docker/supervisord.conf
@@ -25,7 +25,7 @@ autostart=true
 autorestart=true
 
 [program:queue-worker]
-command=/usr/local/bin/php /var/www/html/artisan queue:work --queue=high,standard,low --sleep=3 --tries=3
+command=/usr/local/bin/php /var/www/html/artisan queue:work --tries=3
 user=www-data
 autostart=true
 autorestart=true


### PR DESCRIPTION
We only use the `default` queue instead of high, standard and low. Also we no longer use `--sleep=3` to allow task delays < 3 seconds.

ref https://github.com/pelican-dev/panel/blob/main/app/Console/Commands/Environment/QueueWorkerServiceCommand.php#L50