### PR TITLE
Collection of small admin area changes

### DIFF
--- a/app/Filament/Resources/ApiKeyResource.php
+++ b/app/Filament/Resources/ApiKeyResource.php
@@ -23,13 +23,6 @@ class ApiKeyResource extends Resource
         return false;
     }
 
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
-    }
-
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
+++ b/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
@@ -67,7 +67,7 @@ class ListApiKeys extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label('New API Key')
+                ->label('Create API Key')
                 ->hidden(fn () => ApiKey::where('key_type', ApiKey::TYPE_APPLICATION)->count() <= 0),
         ];
     }

--- a/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
+++ b/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
@@ -68,7 +68,7 @@ class ListApiKeys extends ListRecords
         return [
             Actions\CreateAction::make()
                 ->label('New API Key')
-                ->hidden(fn () => ApiKey::count() <= 0),
+                ->hidden(fn () => ApiKey::where('key_type', ApiKey::TYPE_APPLICATION)->count() <= 0),
         ];
     }
 }

--- a/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
+++ b/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\ApiKeyResource;
 use App\Models\ApiKey;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -51,13 +52,23 @@ class ListApiKeys extends ListRecords
             ])
             ->actions([
                 DeleteAction::make(),
+            ])
+            ->emptyStateIcon('tabler-key')
+            ->emptyStateDescription('')
+            ->emptyStateHeading('No API Keys')
+            ->emptyStateActions([
+                CreateAction::make('create')
+                    ->label('Create API Key')
+                    ->button(),
             ]);
     }
 
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label('New API Key')
+                ->hidden(fn () => ApiKey::count() <= 0),
         ];
     }
 }

--- a/app/Filament/Resources/DatabaseHostResource.php
+++ b/app/Filament/Resources/DatabaseHostResource.php
@@ -20,13 +20,6 @@ class DatabaseHostResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
-    }
-
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Resources/DatabaseHostResource.php
+++ b/app/Filament/Resources/DatabaseHostResource.php
@@ -9,6 +9,7 @@ use Filament\Resources\Resource;
 class DatabaseHostResource extends Resource
 {
     protected static ?string $model = DatabaseHost::class;
+
     protected static ?string $label = 'Database Host';
 
     protected static ?string $navigationIcon = 'tabler-database';

--- a/app/Filament/Resources/DatabaseHostResource.php
+++ b/app/Filament/Resources/DatabaseHostResource.php
@@ -9,8 +9,7 @@ use Filament\Resources\Resource;
 class DatabaseHostResource extends Resource
 {
     protected static ?string $model = DatabaseHost::class;
-
-    protected static ?string $label = 'Databases';
+    protected static ?string $label = 'Database Host';
 
     protected static ?string $navigationIcon = 'tabler-database';
     protected static ?string $navigationGroup = 'Advanced';

--- a/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
@@ -4,13 +4,13 @@ namespace App\Filament\Resources\DatabaseHostResource\Pages;
 
 use App\Filament\Resources\DatabaseHostResource;
 use App\Services\Databases\Hosts\HostCreationService;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\TextInput;
-use Filament\Resources\Pages\CreateRecord;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
+use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
 use PDOException;
 

--- a/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
@@ -7,13 +7,13 @@ use App\Filament\Resources\DatabaseHostResource\RelationManagers\DatabasesRelati
 use App\Models\DatabaseHost;
 use App\Services\Databases\Hosts\HostUpdateService;
 use Filament\Actions;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\TextInput;
-use Filament\Resources\Pages\EditRecord;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
 use PDOException;
 

--- a/app/Filament/Resources/DatabaseHostResource/Pages/ListDatabaseHosts.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/ListDatabaseHosts.php
@@ -3,9 +3,11 @@
 namespace App\Filament\Resources\DatabaseHostResource\Pages;
 
 use App\Filament\Resources\DatabaseHostResource;
+use App\Models\DatabaseHost;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
@@ -45,13 +47,23 @@ class ListDatabaseHosts extends ListRecords
                     DeleteBulkAction::make()
                         ->authorize(fn () => auth()->user()->can('delete databasehost')),
                 ]),
+            ])
+            ->emptyStateIcon('tabler-database')
+            ->emptyStateDescription('')
+            ->emptyStateHeading('No Database Hosts')
+            ->emptyStateActions([
+                CreateAction::make('create')
+                    ->label('Create Database Host')
+                    ->button(),
             ]);
     }
 
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make('create')->label('New Database Host'),
+            Actions\CreateAction::make('create')
+                ->label('New Database Host')
+                ->hidden(fn () => DatabaseHost::count() <= 0),
         ];
     }
 }

--- a/app/Filament/Resources/DatabaseHostResource/Pages/ListDatabaseHosts.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/ListDatabaseHosts.php
@@ -62,7 +62,7 @@ class ListDatabaseHosts extends ListRecords
     {
         return [
             Actions\CreateAction::make('create')
-                ->label('New Database Host')
+                ->label('Create Database Host')
                 ->hidden(fn () => DatabaseHost::count() <= 0),
         ];
     }

--- a/app/Filament/Resources/DatabaseResource.php
+++ b/app/Filament/Resources/DatabaseResource.php
@@ -20,13 +20,6 @@ class DatabaseResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
-    }
-
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Resources/EggResource.php
+++ b/app/Filament/Resources/EggResource.php
@@ -21,13 +21,6 @@ class EggResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
-    }
-
     public static function getGloballySearchableAttributes(): array
     {
         return ['name', 'tags', 'uuid', 'id'];

--- a/app/Filament/Resources/EggResource/Pages/CreateEgg.php
+++ b/app/Filament/Resources/EggResource/Pages/CreateEgg.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\EggResource\Pages;
 
+use AbdelhamidErrahmouni\FilamentMonacoEditor\MonacoEditor;
 use App\Filament\Resources\EggResource;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Fieldset;
@@ -15,10 +16,9 @@ use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Forms\Form;
 use Filament\Forms\Set;
 use Filament\Resources\Pages\CreateRecord;
-use AbdelhamidErrahmouni\FilamentMonacoEditor\MonacoEditor;
-use Filament\Forms\Form;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 

--- a/app/Filament/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Resources/EggResource/Pages/EditEgg.php
@@ -40,6 +40,7 @@ class EditEgg extends EditRecord
                 Tabs::make()->tabs([
                     Tab::make('Configuration')
                         ->columns(['default' => 1, 'sm' => 1, 'md' => 2, 'lg' => 4])
+                        ->icon('tabler-egg')
                         ->schema([
                             TextInput::make('name')
                                 ->required()
@@ -106,9 +107,9 @@ class EditEgg extends EditRecord
                                 ->valueLabel('Image URI')
                                 ->helperText('The docker images available to servers using this egg.'),
                         ]),
-
                     Tab::make('Process Management')
                         ->columns()
+                        ->icon('tabler-server-cog')
                         ->schema([
                             Select::make('config_from')
                                 ->label('Copy Settings From')
@@ -131,6 +132,7 @@ class EditEgg extends EditRecord
                         ]),
                     Tab::make('Egg Variables')
                         ->columnSpanFull()
+                        ->icon('tabler-variable')
                         ->schema([
                             Repeater::make('variables')
                                 ->label('')
@@ -212,6 +214,7 @@ class EditEgg extends EditRecord
                         ]),
                     Tab::make('Install Script')
                         ->columns(3)
+                        ->icon('tabler-file-download')
                         ->schema([
                             Select::make('copy_script_from')
                                 ->placeholder('None')
@@ -231,7 +234,6 @@ class EditEgg extends EditRecord
                                 ->language('shell')
                                 ->view('filament.plugins.monaco-editor'),
                         ]),
-
                 ])->columnSpanFull()->persistTabInQueryString(),
             ]);
     }

--- a/app/Filament/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Resources/EggResource/Pages/EditEgg.php
@@ -80,6 +80,7 @@ class EditEgg extends EditRecord
                                 ->helperText('')
                                 ->columnSpan(['default' => 1, 'sm' => 1, 'md' => 2, 'lg' => 2]),
                             Toggle::make('force_outgoing_ip')
+                                ->inline(false)
                                 ->hintIcon('tabler-question-mark')
                                 ->hintIconTooltip("Forces all outgoing network traffic to have its Source IP NATed to the IP of the server's primary allocation IP.
                                     Required for certain games to work properly when the Node has multiple public IP addresses.

--- a/app/Filament/Resources/EggResource/RelationManagers/ServersRelationManager.php
+++ b/app/Filament/Resources/EggResource/RelationManagers/ServersRelationManager.php
@@ -16,7 +16,7 @@ class ServersRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('servers')
-            ->emptyStateDescription('No Servers')->emptyStateHeading('No servers are assigned this egg.')
+            ->emptyStateDescription('No Servers')->emptyStateHeading('No servers are assigned to this Egg.')
             ->searchable(false)
             ->columns([
                 TextColumn::make('user.username')

--- a/app/Filament/Resources/MountResource.php
+++ b/app/Filament/Resources/MountResource.php
@@ -18,13 +18,6 @@ class MountResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
-    }
-
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Resources/MountResource/Pages/EditMount.php
+++ b/app/Filament/Resources/MountResource/Pages/EditMount.php
@@ -4,14 +4,14 @@ namespace App\Filament\Resources\MountResource\Pages;
 
 use App\Filament\Resources\MountResource;
 use Filament\Actions;
-use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\ToggleButtons;
-use Filament\Resources\Pages\EditRecord;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\ToggleButtons;
 use Filament\Forms\Form;
+use Filament\Resources\Pages\EditRecord;
 
 class EditMount extends EditRecord
 {

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -3,8 +3,8 @@
 namespace App\Filament\Resources\NodeResource\Pages;
 
 use App\Filament\Resources\NodeResource;
-use Filament\Forms\Components\Actions\Action;
 use Filament\Forms;
+use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
@@ -230,11 +230,7 @@ class CreateNode extends CreateRecord
                                     false => 'danger',
                                 ]),
                             TagsInput::make('tags')
-                                ->label('Tags')
-                                ->disabled()
-                                ->placeholder('Not Implemented')
-                                ->hintIcon('tabler-question-mark')
-                                ->hintIconTooltip('Not Implemented')
+                                ->placeholder('Add Tags')
                                 ->columnSpan(2),
                             TextInput::make('upload_size')
                                 ->label('Upload Limit')

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -220,7 +220,7 @@ class CreateNode extends CreateRecord
                             ToggleButtons::make('public')
                                 ->default(true)
                                 ->columnSpan(1)
-                                ->label('Automatic Allocation')->inline()
+                                ->label('Use Node for deployment?')->inline()
                                 ->options([
                                     true => 'Yes',
                                     false => 'No',

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -153,7 +153,6 @@ class CreateNode extends CreateRecord
                                     'lg' => 2,
                                 ])
                                 ->required()
-                                ->regex('/[a-zA-Z0-9_\.\- ]+/')
                                 ->helperText('This name is for display only and can be changed later.')
                                 ->maxLength(100),
 

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -182,7 +182,6 @@ class EditNode extends EditRecord
                                     'lg' => 2,
                                 ])
                                 ->required()
-                                ->regex('/[a-zA-Z0-9_\.\- ]+/')
                                 ->helperText('This name is for display only and can be changed later.')
                                 ->maxLength(100),
 

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -235,11 +235,7 @@ class EditNode extends EditRecord
                                 ->disabled(),
                             TagsInput::make('tags')
                                 ->columnSpan(['default' => 1, 'sm' => 1, 'md' => 2, 'lg' => 2])
-                                ->label('Tags')
-                                ->disabled()
-                                ->placeholder('Not Implemented')
-                                ->hintIcon('tabler-question-mark')
-                                ->hintIconTooltip('Not Implemented'),
+                                ->placeholder('Add Tags'),
                             TextInput::make('upload_size')
                                 ->columnSpan(['default' => 1, 'sm' => 1, 'md' => 2, 'lg' => 1])
                                 ->label('Upload Limit')

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -259,7 +259,7 @@ class EditNode extends EditRecord
                                 ->helperText('Display alias for the SFTP address. Leave empty to use the Node FQDN.'),
                             ToggleButtons::make('public')
                                 ->columnSpan(['default' => 1, 'sm' => 1, 'md' => 1, 'lg' => 3])
-                                ->label('Automatic Allocation')->inline()
+                                ->label('Use Node for deployment?')->inline()
                                 ->options([
                                     true => 'Yes',
                                     false => 'No',

--- a/app/Filament/Resources/NodeResource/Pages/ListNodes.php
+++ b/app/Filament/Resources/NodeResource/Pages/ListNodes.php
@@ -58,7 +58,7 @@ class ListNodes extends ListRecords
                     ->sortable(),
                 TextColumn::make('cpu')
                     ->visibleFrom('sm')
-                    ->icon('tabler-file')
+                    ->icon('tabler-cpu')
                     ->numeric()
                     ->suffix(' %')
                     ->sortable(),

--- a/app/Filament/Resources/NodeResource/RelationManagers/NodesRelationManager.php
+++ b/app/Filament/Resources/NodeResource/RelationManagers/NodesRelationManager.php
@@ -3,10 +3,10 @@
 namespace App\Filament\Resources\NodeResource\RelationManagers;
 
 use App\Models\Server;
+use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Filament\Resources\RelationManagers\RelationManager;
 
 class NodesRelationManager extends RelationManager
 {

--- a/app/Filament/Resources/ServerResource.php
+++ b/app/Filament/Resources/ServerResource.php
@@ -19,13 +19,6 @@ class ServerResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
-    }
-
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/CreateServer.php
@@ -11,6 +11,9 @@ use App\Services\Allocations\AssignmentService;
 use App\Services\Servers\RandomWordService;
 use App\Services\Servers\ServerCreationService;
 use App\Services\Users\UserCreationService;
+use Closure;
+use Exception;
+use Filament\Forms;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Component;
@@ -26,6 +29,7 @@ use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
+use Filament\Forms\Components\Wizard;
 use Filament\Forms\Components\Wizard\Step;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
@@ -33,12 +37,10 @@ use Filament\Forms\Set;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Filament\Forms;
-use Filament\Forms\Components\Wizard;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\HtmlString;
-use Closure;
+use LogicException;
 
 class CreateServer extends CreateRecord
 {
@@ -633,7 +635,7 @@ class CreateServer extends CreateRecord
                                                         'unlimited' => -1,
                                                         'disabled' => 0,
                                                         'limited' => 128,
-                                                        default => throw new \LogicException('Invalid state'),
+                                                        default => throw new LogicException('Invalid state'),
                                                     };
 
                                                     $set('swap', $value);
@@ -843,7 +845,7 @@ class CreateServer extends CreateRecord
             return !$containsRuleIn;
         }
 
-        throw new \Exception('Component type not supported: ' . $component::class);
+        throw new Exception('Component type not supported: ' . $component::class);
     }
 
     private function getSelectOptionsFromRules(Get $get): array

--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -2,42 +2,43 @@
 
 namespace App\Filament\Resources\ServerResource\Pages;
 
+use App\Enums\ContainerStatus;
+use App\Enums\ServerState;
+use App\Filament\Resources\ServerResource;
+use App\Http\Controllers\Admin\ServersController;
 use App\Models\Database;
+use App\Models\Egg;
+use App\Models\Server;
+use App\Models\ServerVariable;
 use App\Services\Databases\DatabaseManagementService;
 use App\Services\Databases\DatabasePasswordService;
+use App\Services\Servers\RandomWordService;
+use App\Services\Servers\ServerDeletionService;
+use App\Services\Servers\SuspensionService;
+use App\Services\Servers\TransferServerService;
+use Closure;
+use Exception;
+use Filament\Actions;
+use Filament\Forms;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Tabs;
 use Filament\Forms\Components\Tabs\Tab;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
+use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
-use LogicException;
-use App\Filament\Resources\ServerResource;
-use App\Http\Controllers\Admin\ServersController;
-use App\Services\Servers\RandomWordService;
-use App\Services\Servers\SuspensionService;
-use App\Services\Servers\TransferServerService;
-use Filament\Actions;
-use Filament\Forms;
-use App\Enums\ContainerStatus;
-use App\Enums\ServerState;
-use App\Models\Egg;
-use App\Models\Server;
-use App\Models\ServerVariable;
-use App\Services\Servers\ServerDeletionService;
-use Filament\Forms\Components\Tabs;
-use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
-use Illuminate\Support\Facades\Validator;
-use Closure;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Validator;
+use LogicException;
 use Webbingbrasil\FilamentCopyActions\Forms\Actions\CopyAction;
 
 class EditServer extends EditRecord
@@ -796,7 +797,7 @@ class EditServer extends EditRecord
             return $containsRuleIn;
         }
 
-        throw new \Exception('Component type not supported: ' . $component::class);
+        throw new Exception('Component type not supported: ' . $component::class);
     }
 
     private function getSelectOptionsFromRules(ServerVariable $serverVariable): array

--- a/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
@@ -7,8 +7,8 @@ use App\Models\Server;
 use App\Services\Allocations\AssignmentService;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Set;
 use Filament\Forms\Form;
+use Filament\Forms\Set;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
@@ -43,8 +43,6 @@ class AllocationsRelationManager extends RelationManager
             ->recordTitleAttribute('ip')
             ->recordTitle(fn (Allocation $allocation) => "$allocation->ip:$allocation->port")
             ->checkIfRecordIsSelectableUsing(fn (Allocation $record) => $record->id !== $this->getOwnerRecord()->allocation_id)
-            // ->actions
-            // ->groups
             ->inverseRelationship('server')
             ->columns([
                 TextColumn::make('ip')->label('IP'),
@@ -62,9 +60,6 @@ class AllocationsRelationManager extends RelationManager
                     ->action(fn (Allocation $allocation) => $this->getOwnerRecord()->update(['allocation_id' => $allocation->id]))
                     ->default(fn (Allocation $allocation) => $allocation->id === $this->getOwnerRecord()->allocation_id)
                     ->label('Primary'),
-            ])
-            ->filters([
-                //
             ])
             ->actions([
                 Action::make('make-primary')

--- a/app/Filament/Resources/UserResource/Pages/EditProfile.php
+++ b/app/Filament/Resources/UserResource/Pages/EditProfile.php
@@ -21,13 +21,14 @@ use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Tabs;
-use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Tabs\Tab;
+use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Get;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\HtmlString;
 use Illuminate\Validation\Rules\Password;
@@ -273,7 +274,7 @@ class EditProfile extends \Filament\Pages\Auth\EditProfile
         ];
     }
 
-    protected function handleRecordUpdate($record, $data): \Illuminate\Database\Eloquent\Model
+    protected function handleRecordUpdate($record, $data): Model
     {
         if ($token = $data['2facode'] ?? null) {
             /** @var ToggleTwoFactorService $service */

--- a/app/Filament/Resources/UserResource/RelationManagers/ServersRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/ServersRelationManager.php
@@ -6,11 +6,11 @@ use App\Enums\ServerState;
 use App\Models\Server;
 use App\Models\User;
 use App\Services\Servers\SuspensionService;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions;
 use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Filament\Tables\Actions;
-use Filament\Resources\RelationManagers\RelationManager;
 
 class ServersRelationManager extends RelationManager
 {

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -79,7 +79,7 @@ class Node extends Model
     ];
 
     public static array $validationRules = [
-        'name' => 'required|regex:/^([\w .-]{1,100})$/',
+        'name' => 'required|string|min:1|max:100',
         'description' => 'string|nullable',
         'public' => 'boolean',
         'fqdn' => 'required|string',

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -5,12 +5,12 @@ namespace App\Models;
 use App\Exceptions\Service\HasActiveServersException;
 use App\Repositories\Daemon\DaemonConfigurationRepository;
 use Exception;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Symfony\Component\Yaml\Yaml;
-use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 /**
  * @property int $id
@@ -75,7 +75,7 @@ class Node extends Model
         'disk_overallocate', 'cpu', 'cpu_overallocate',
         'upload_size', 'daemon_base',
         'daemon_sftp', 'daemon_sftp_alias', 'daemon_listen',
-        'description', 'maintenance_mode',
+        'description', 'maintenance_mode', 'tags',
     ];
 
     public static array $validationRules = [

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -24,7 +24,7 @@ class AdminPanelProvider extends PanelProvider
     public function boot()
     {
         FilamentAsset::registerCssVariables([
-            'sidebar-width' => '14rem !important',
+            'sidebar-width' => '16rem !important',
         ]);
     }
 


### PR DESCRIPTION
Many little things that were left todo in the admin area.

- Enabled the tag inputs for nodes
- Updated the icon of the cpu column for nodes
- Disabled `inline` for `Force outgoing ip` toggle
- Changed label for `Database Hosts`
- Added custom empty states for `Database Hosts` & `API Keys`
- Added Icons to the tabs on the EditEgg page
- Fixed a small typo in `ServersRelationManager`
- Renamed Node `Automatic Allocation` (`public` field) to avoid confusion with the `Automatic Allocations` (allow clients to create allocations via the frontend)
- Ran code cleanup (mainly reordered imports or removed unnecessary code)
- Removed regex for node display name