### PR TITLE
Fix escaping for `EnvironmentWriterTrait`

### DIFF
--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -92,7 +92,6 @@ class Settings extends Page implements HasForms
             TextInput::make('APP_NAME')
                 ->label('App Name')
                 ->required()
-                ->alphaNum()
                 ->default(env('APP_NAME', 'Pelican')),
             TextInput::make('APP_FAVICON')
                 ->label('App Favicon')

--- a/app/Traits/EnvironmentWriterTrait.php
+++ b/app/Traits/EnvironmentWriterTrait.php
@@ -14,7 +14,7 @@ trait EnvironmentWriterTrait
     public function escapeEnvironmentValue(string $value): string
     {
         if (!preg_match('/^\"(.*)\"$/', $value) && preg_match('/([^\w.\-+\/])+/', $value)) {
-            return sprintf('"%s"', addslashes($value));
+            return sprintf('"%s"', addcslashes($value, '\\"'));
         }
 
         return $value;

--- a/tests/Unit/Helpers/EnvironmentWriterTraitTest.php
+++ b/tests/Unit/Helpers/EnvironmentWriterTraitTest.php
@@ -23,6 +23,7 @@ class EnvironmentWriterTraitTest extends TestCase
             ['foo', 'foo'],
             ['abc123', 'abc123'],
             ['val"ue', '"val\"ue"'],
+            ['val\'ue', '"val\'ue"'],
             ['my test value', '"my test value"'],
             ['mysql_p@assword', '"mysql_p@assword"'],
             ['mysql_p#assword', '"mysql_p#assword"'],


### PR DESCRIPTION
Properly fixes #562