### PR TITLE
Update API for roles

### DIFF
--- a/app/Http/Controllers/Api/Application/Roles/RoleController.php
+++ b/app/Http/Controllers/Api/Application/Roles/RoleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Roles;
 
+use App\Exceptions\PanelException;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use App\Models\Role;
@@ -67,6 +68,10 @@ class RoleController extends ApplicationApiController
      */
     public function update(UpdateRoleRequest $request, Role $role): array
     {
+        if ($role->isRootAdmin()) {
+            throw new PanelException('Can\'t update root admin role!');
+        }
+
         $role->update($request->validated());
 
         return $this->fractal->item($role)
@@ -81,6 +86,10 @@ class RoleController extends ApplicationApiController
      */
     public function delete(DeleteRoleRequest $request, Role $role): Response
     {
+        if ($role->isRootAdmin()) {
+            throw new PanelException('Can\'t delete root admin role!');
+        }
+
         $role->delete();
 
         return $this->returnNoContent();

--- a/app/Http/Controllers/Api/Application/Roles/RoleController.php
+++ b/app/Http/Controllers/Api/Application/Roles/RoleController.php
@@ -21,8 +21,8 @@ class RoleController extends ApplicationApiController
     public function index(GetRoleRequest $request): array
     {
         $roles = QueryBuilder::for(Role::query())
-            ->allowedFilters(['name'])
-            ->allowedSorts(['name'])
+            ->allowedFilters(['id', 'name'])
+            ->allowedSorts(['id', 'name'])
             ->paginate($request->query('per_page') ?? 10);
 
         return $this->fractal->collection($roles)

--- a/app/Http/Controllers/Api/Application/Users/UserController.php
+++ b/app/Http/Controllers/Api/Application/Users/UserController.php
@@ -82,8 +82,13 @@ class UserController extends ApplicationApiController
      */
     public function assignRoles(AssignUserRolesRequest $request, User $user): array
     {
-        $roles = collect($request->input('roles'))->except(Role::getRootAdmin()->id);
-        $user->assignRole($roles);
+        foreach ($request->input('roles') as $role) {
+            if ($role === Role::getRootAdmin()->id) {
+                continue;
+            }
+
+            $user->assignRole($role);
+        }
 
         $response = $this->fractal->item($user)
             ->transformWith($this->getTransformer(UserTransformer::class));
@@ -96,8 +101,13 @@ class UserController extends ApplicationApiController
      */
     public function removeRoles(AssignUserRolesRequest $request, User $user): array
     {
-        $roles = collect($request->input('roles'))->except(Role::getRootAdmin()->id);
-        $user->removeRoles($roles);
+        foreach ($request->input('roles') as $role) {
+            if ($role === Role::getRootAdmin()->id) {
+                continue;
+            }
+
+            $user->removeRole($role);
+        }
 
         $response = $this->fractal->item($user)
             ->transformWith($this->getTransformer(UserTransformer::class));

--- a/app/Http/Controllers/Api/Application/Users/UserController.php
+++ b/app/Http/Controllers/Api/Application/Users/UserController.php
@@ -14,6 +14,7 @@ use App\Http\Requests\Api\Application\Users\DeleteUserRequest;
 use App\Http\Requests\Api\Application\Users\UpdateUserRequest;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Users\AssignUserRolesRequest;
+use App\Models\Role;
 
 class UserController extends ApplicationApiController
 {
@@ -81,7 +82,8 @@ class UserController extends ApplicationApiController
      */
     public function roles(AssignUserRolesRequest $request, User $user): array
     {
-        $user->syncRoles($request->input('roles'));
+        $roles = collect($request->input('roles'))->except(Role::getRootAdmin()->id);
+        $user->syncRoles($roles);
 
         $response = $this->fractal->item($user)
             ->transformWith($this->getTransformer(UserTransformer::class));

--- a/app/Http/Controllers/Api/Application/Users/UserController.php
+++ b/app/Http/Controllers/Api/Application/Users/UserController.php
@@ -80,10 +80,24 @@ class UserController extends ApplicationApiController
     /**
      * Assign roles to a user.
      */
-    public function roles(AssignUserRolesRequest $request, User $user): array
+    public function assignRoles(AssignUserRolesRequest $request, User $user): array
     {
         $roles = collect($request->input('roles'))->except(Role::getRootAdmin()->id);
-        $user->syncRoles($roles);
+        $user->assignRole($roles);
+
+        $response = $this->fractal->item($user)
+            ->transformWith($this->getTransformer(UserTransformer::class));
+
+        return $response->toArray();
+    }
+
+    /**
+     * Removes roles from a user.
+     */
+    public function removeRoles(AssignUserRolesRequest $request, User $user): array
+    {
+        $roles = collect($request->input('roles'))->except(Role::getRootAdmin()->id);
+        $user->removeRoles($roles);
 
         $response = $this->fractal->item($user)
             ->transformWith($this->getTransformer(UserTransformer::class));

--- a/app/Http/Requests/Api/Application/Roles/StoreRoleRequest.php
+++ b/app/Http/Requests/Api/Application/Roles/StoreRoleRequest.php
@@ -15,7 +15,6 @@ class StoreRoleRequest extends ApplicationApiRequest
     {
         return [
             'name' => 'required|string',
-            'guard_name' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/Api/Application/Users/AssignUserRolesRequest.php
+++ b/app/Http/Requests/Api/Application/Users/AssignUserRolesRequest.php
@@ -11,7 +11,7 @@ class AssignUserRolesRequest extends StoreUserRequest
     {
         return [
             'roles' => 'array',
-            'roles.*' => 'string',
+            'roles.*' => 'int',
         ];
     }
 }

--- a/app/Transformers/Api/Application/RolePermissionTransformer.php
+++ b/app/Transformers/Api/Application/RolePermissionTransformer.php
@@ -15,7 +15,6 @@ class RolePermissionTransformer extends BaseTransformer
     {
         return [
             'name' => $model->name,
-            'guard_name' => $model->guard_name,
             'created_at' => $model->created_at->toAtomString(),
             'updated_at' => $model->updated_at->toAtomString(),
         ];

--- a/app/Transformers/Api/Application/RoleTransformer.php
+++ b/app/Transformers/Api/Application/RoleTransformer.php
@@ -26,8 +26,8 @@ class RoleTransformer extends BaseTransformer
     public function transform(Role $model): array
     {
         return [
+            'id' => $model->id,
             'name' => $model->name,
-            'guard_name' => $model->guard_name,
             'created_at' => $model->created_at->toAtomString(),
             'updated_at' => $model->updated_at->toAtomString(),
         ];

--- a/routes/api-application.php
+++ b/routes/api-application.php
@@ -19,7 +19,8 @@ Route::prefix('/users')->group(function () {
     Route::post('/', [Application\Users\UserController::class, 'store']);
     Route::patch('/{user:id}', [Application\Users\UserController::class, 'update']);
 
-    Route::patch('/{user:id}/roles', [Application\Users\UserController::class, 'roles']);
+    Route::patch('/{user:id}/roles/assign', [Application\Users\UserController::class, 'assignRoles']);
+    Route::patch('/{user:id}/roles/remove', [Application\Users\UserController::class, 'removeRoles']);
 
     Route::delete('/{user:id}', [Application\Users\UserController::class, 'delete']);
 });


### PR DESCRIPTION
- Makes sure you can't update/ delete/ assign the `Root Admin` role.
- Removes `guard_name` from role transformer.
- Adds `id` to role transformer.
- Adds endpoint to remove user roles.