### PR TITLE
Add warning about database data to database settings command

### DIFF
--- a/app/Console/Commands/Environment/DatabaseSettingsCommand.php
+++ b/app/Console/Commands/Environment/DatabaseSettingsCommand.php
@@ -42,6 +42,13 @@ class DatabaseSettingsCommand extends Command
      */
     public function handle(): int
     {
+        $this->error('Changing the database driver will NOT move any database data!');
+        $this->error('Please make sure you made a database backup first!');
+        $this->error('After changing the driver you will have to manually move the old data to the new database.');
+        if (!$this->confirm('Do you want to continue?')) {
+            return 1;
+        }
+
         $selected = config('database.default', 'sqlite');
         $this->variables['DB_CONNECTION'] = $this->option('driver') ?? $this->choice(
             'Database Driver',


### PR DESCRIPTION
The old database data is not moved when changing the driver. So the panel will be effectively empty. It's probably a good idea to inform the user about that.