### PR TITLE
Auto-check eggs for update

### DIFF
--- a/app/Console/Commands/Egg/CheckEggUpdates.php
+++ b/app/Console/Commands/Egg/CheckEggUpdates.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands\Egg;
+
+use App\Models\Egg;
+use App\Services\Eggs\Sharing\EggExporterService;
+use Exception;
+use Illuminate\Console\Command;
+
+class CheckEggUpdates extends Command
+{
+    protected $signature = 'p:egg:check-updates';
+
+    public function handle(): void
+    {
+        /** @var EggExporterService $exporterService */
+        $exporterService = app(EggExporterService::class);
+
+        $eggs = Egg::all();
+        foreach ($eggs as $egg) {
+            try {
+                if (is_null($egg->update_url)) {
+                    $this->comment("{$egg->name}: Skipping (no update url set)");
+
+                    continue;
+                }
+
+                $currentJson = json_decode($exporterService->handle($egg->id));
+                unset($currentJson['exported_at']);
+
+                $updatedJson = json_decode(file_get_contents($egg->update_url));
+                unset($updatedJson['exported_at']);
+
+                if (md5(json_encode($currentJson)) === md5(json_encode($updatedJson))) {
+                    $this->info("{$egg->name}: Up-to-date");
+                    cache()->put("eggs.{$egg->uuid}.update", false, now()->addHour());
+                } else {
+                    $this->warn("{$egg->name}: Found update");
+                    cache()->put("eggs.{$egg->uuid}.update", true, now()->addHour());
+                }
+            } catch (Exception $exception) {
+                $this->error("{$egg->name}: Error ({$exception->getMessage()})");
+            }
+        }
+    }
+}

--- a/app/Console/Commands/Egg/CheckEggUpdates.php
+++ b/app/Console/Commands/Egg/CheckEggUpdates.php
@@ -26,10 +26,10 @@ class CheckEggUpdates extends Command
                 }
 
                 $currentJson = json_decode($exporterService->handle($egg->id));
-                unset($currentJson['exported_at']);
+                unset($currentJson->exported_at);
 
                 $updatedJson = json_decode(file_get_contents($egg->update_url));
-                unset($updatedJson['exported_at']);
+                unset($updatedJson->exported_at);
 
                 if (md5(json_encode($currentJson)) === md5(json_encode($updatedJson))) {
                     $this->info("{$egg->name}: Up-to-date");

--- a/app/Console/Commands/Egg/CheckEggUpdatesCommand.php
+++ b/app/Console/Commands/Egg/CheckEggUpdatesCommand.php
@@ -7,7 +7,7 @@ use App\Services\Eggs\Sharing\EggExporterService;
 use Exception;
 use Illuminate\Console\Command;
 
-class CheckEggUpdates extends Command
+class CheckEggUpdatesCommand extends Command
 {
     protected $signature = 'p:egg:check-updates';
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\Egg\CheckEggUpdates;
 use App\Jobs\NodeStatistics;
 use App\Models\ActivityLog;
 use Illuminate\Console\Scheduling\Schedule;
@@ -35,6 +36,7 @@ class Kernel extends ConsoleKernel
 
         $schedule->command(CleanServiceBackupFilesCommand::class)->daily();
         $schedule->command(PruneImagesCommand::class)->daily();
+        $schedule->command(CheckEggUpdates::class)->hourly();
 
         $schedule->job(new NodeStatistics())->everyFiveSeconds()->withoutOverlapping();
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,16 +2,16 @@
 
 namespace App\Console;
 
-use App\Console\Commands\Egg\CheckEggUpdates;
+use App\Console\Commands\Egg\CheckEggUpdatesCommand;
+use App\Console\Commands\Maintenance\CleanServiceBackupFilesCommand;
+use App\Console\Commands\Maintenance\PruneImagesCommand;
+use App\Console\Commands\Maintenance\PruneOrphanedBackupsCommand;
+use App\Console\Commands\Schedule\ProcessRunnableCommand;
 use App\Jobs\NodeStatistics;
 use App\Models\ActivityLog;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-use App\Console\Commands\Schedule\ProcessRunnableCommand;
-use App\Console\Commands\Maintenance\PruneOrphanedBackupsCommand;
-use App\Console\Commands\Maintenance\CleanServiceBackupFilesCommand;
-use App\Console\Commands\Maintenance\PruneImagesCommand;
 
 class Kernel extends ConsoleKernel
 {
@@ -36,7 +36,7 @@ class Kernel extends ConsoleKernel
 
         $schedule->command(CleanServiceBackupFilesCommand::class)->daily();
         $schedule->command(PruneImagesCommand::class)->daily();
-        $schedule->command(CheckEggUpdates::class)->hourly();
+        $schedule->command(CheckEggUpdatesCommand::class)->hourly();
 
         $schedule->job(new NodeStatistics())->everyFiveSeconds()->withoutOverlapping();
 

--- a/app/Filament/Resources/EggResource/Pages/ListEggs.php
+++ b/app/Filament/Resources/EggResource/Pages/ListEggs.php
@@ -14,7 +14,7 @@ use Filament\Forms\Components\Tabs\Tab;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
-use Filament\Tables;
+use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Actions\EditAction;
@@ -49,7 +49,7 @@ class ListEggs extends ListRecords
             ])
             ->actions([
                 EditAction::make(),
-                Tables\Actions\Action::make('export')
+                Action::make('export')
                     ->icon('tabler-download')
                     ->label('Export')
                     ->color('primary')
@@ -57,6 +57,33 @@ class ListEggs extends ListRecords
                         echo $service->handle($egg->id);
                     }, 'egg-' . $egg->getKebabName() . '.json'))
                     ->authorize(fn () => auth()->user()->can('export egg')),
+                Action::make('update')
+                    ->icon('tabler-cloud-download')
+                    ->label('Update')
+                    ->color('success')
+                    ->action(function (Egg $egg) {
+                        try {
+                            app(EggImporterService::class)->fromUrl($egg->update_url, $egg);
+                            cache()->forget("eggs.{$egg->uuid}.update");
+                        } catch (Exception $exception) {
+                            Notification::make()
+                                ->title('Update Failed')
+                                ->body($exception->getMessage())
+                                ->danger()
+                                ->send();
+
+                            report($exception);
+
+                            return;
+                        }
+
+                        Notification::make()
+                            ->title('Update started')
+                            ->success()
+                            ->send();
+                    })
+                    ->authorize(fn () => auth()->user()->can('import egg'))
+                    ->visible(fn (Egg $egg) => cache()->get("eggs.{$egg->uuid}.update", false)),
             ])
             ->bulkActions([
                 BulkActionGroup::make([

--- a/app/Filament/Resources/EggResource/Pages/ListEggs.php
+++ b/app/Filament/Resources/EggResource/Pages/ListEggs.php
@@ -61,13 +61,18 @@ class ListEggs extends ListRecords
                     ->icon('tabler-cloud-download')
                     ->label('Update')
                     ->color('success')
+                    ->requiresConfirmation()
+                    ->modalHeading('Are you sure you want to update this egg?')
+                    ->modalDescription('If you made any changes to the egg they will be overwritten!')
+                    ->modalIconColor('danger')
+                    ->modalSubmitAction(fn (Actions\StaticAction $action) => $action->color('danger'))
                     ->action(function (Egg $egg) {
                         try {
                             app(EggImporterService::class)->fromUrl($egg->update_url, $egg);
                             cache()->forget("eggs.{$egg->uuid}.update");
                         } catch (Exception $exception) {
                             Notification::make()
-                                ->title('Update Failed')
+                                ->title('Egg Update failed')
                                 ->body($exception->getMessage())
                                 ->danger()
                                 ->send();
@@ -78,7 +83,7 @@ class ListEggs extends ListRecords
                         }
 
                         Notification::make()
-                            ->title('Update started')
+                            ->title('Egg updated')
                             ->success()
                             ->send();
                     })


### PR DESCRIPTION
Adds a new command to check installed eggs for updates. This just fetches the json from the `update_url` and compares it with the current json. (or rather the hashes of the json files) It runs automatically every hour.

If an update is found it will also display a button on the eggs list that will simply re-import the updated egg json.

_This will also mean that if you edit an egg it will detect it as "outdated"!_