### PR TITLE
Cleanup `.env.example` and configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,7 @@
 APP_ENV=production
 APP_DEBUG=false
 APP_KEY=
-APP_TIMEZONE=UTC
 APP_URL=http://panel.test
-APP_LOCALE=en
 APP_INSTALLED=false
-
-LOG_CHANNEL=daily
-LOG_STACK=single
-LOG_DEPRECATIONS_CHANNEL=null
-LOG_LEVEL=debug
-
-DB_CONNECTION=sqlite
-
-CACHE_STORE=file
-QUEUE_CONNECTION=database
-SESSION_DRIVER=file
-
-MAIL_MAILER=log
-MAIL_HOST=smtp.example.com
-MAIL_PORT=25
-MAIL_USERNAME=
-MAIL_PASSWORD=
-MAIL_ENCRYPTION=tls
-MAIL_FROM_ADDRESS=no-reply@example.com
-MAIL_FROM_NAME="Pelican Admin"
-# Set this to your domain to prevent it defaulting to 'localhost', causing mail servers such as Gmail to reject your mail
-# MAIL_EHLO_DOMAIN=panel.example.com
-
-SESSION_ENCRYPT=false
-SESSION_PATH=/
-SESSION_DOMAIN=null
-SESSION_COOKIE=pelican_session
+APP_TIMEZONE=UTC
+APP_LOCALE=en

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'default' => env('LOG_CHANNEL', 'daily'),
+
+];

--- a/config/mail.php
+++ b/config/mail.php
@@ -2,6 +2,13 @@
 
 return [
 
+    'default' => env('MAIL_MAILER', 'log'),
+
+    'from' => [
+        'address' => env('MAIL_FROM_ADDRESS', 'no-reply@example.com'),
+        'name' => env('MAIL_FROM_NAME', 'Pelican Admin'),
+    ],
+
     'mailers' => [
         'mailgun' => [
             'transport' => 'mailgun',

--- a/config/session.php
+++ b/config/session.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'driver' => env('SESSION_DRIVER', 'file'),
+
+    'cookie' => env('SESSION_COOKIE', 'pelican_session'),
+
+];


### PR DESCRIPTION
Removes a bunch of unnecessary env variables from the example .env and adds some of our default values as config defaults instead.