### PR TITLE
Fix docker build workflow

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,5 @@
 {
+    admin off
     email {$ADMIN_EMAIL}
 }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ RUN touch .env
 RUN composer install --no-dev --optimize-autoloader
 
 # Set file permissions
-RUN chmod -R 755 storage \
-    && chmod -R 755 bootstrap/cache
+RUN chmod -R 755 storage bootstrap/cache
 
 # Add scheduler to cron
 RUN echo "* * * * * php /var/www/html/artisan schedule:run >> /dev/null 2>&1" | crontab -u www-data -

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /build
 
 COPY . ./
 
-RUN yarn install --frozen-lockfile && yarn run build:production
+RUN yarn config set network-timeout 300000 \
+    && yarn install --frozen-lockfile \
+    && yarn run build:production
 
 FROM php:8.3-fpm-alpine
 # FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine
@@ -36,8 +38,8 @@ RUN touch .env
 RUN composer install --no-dev --optimize-autoloader
 
 # Set file permissions
-RUN chmod -R 755 /var/www/html/storage \
-    && chmod -R 755 /var/www/html/bootstrap/cache
+RUN chmod -R 755 storage \
+    && chmod -R 755 bootstrap/cache
 
 # Add scheduler to cron
 RUN echo "* * * * * php /var/www/html/artisan schedule:run >> /dev/null 2>&1" | crontab -u www-data -
@@ -49,8 +51,7 @@ RUN cp .github/docker/supervisord.conf /etc/supervisord.conf && \
 HEALTHCHECK --interval=5m --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost/up || exit 1
 
-EXPOSE 80:2019
-EXPOSE 443
+EXPOSE 80 443
 
 VOLUME /pelican-data
 


### PR DESCRIPTION
- [x] Add 300000 timeout cause of github free plan
- [x] Remove unnecessary `/var/www/html` when the WORKDIR is already set
- [x] Expose to 80 & 443 instead of 2019 443
- [x] Disable Caddy admin endpoint to expose 80:80 instead of 80:2019