### PR TITLE
Allow rootadmin role

### DIFF
--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -38,7 +38,7 @@ class EditUser extends EditRecord
                     Hidden::make('skipValidation')->default(true),
                     CheckboxList::make('roles')
                         ->disabled(fn (User $user) => $user->id === auth()->user()->id)
-                        ->disableOptionWhen(fn (string $value): bool => $value == Role::getRootAdmin()->id)
+                        //->disableOptionWhen(fn (string $value): bool => $value == Role::getRootAdmin()->id) TODO: add this back when #416 gets merged
                         ->relationship('roles', 'name')
                         ->label('Admin Roles')
                         ->columnSpanFull()

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -101,7 +101,7 @@ class ListUsers extends ListRecords
                                 ->hintIconTooltip('Providing a user password is optional. New user email will prompt users to create a password the first time they login.')
                                 ->password(),
                             CheckboxList::make('roles')
-                                ->disableOptionWhen(fn (string $value): bool => $value == Role::getRootAdmin()->id)
+                                //->disableOptionWhen(fn (string $value): bool => $value == Role::getRootAdmin()->id) TODO: add this back when #416 gets merged
                                 ->relationship('roles', 'name')
                                 ->dehydrated()
                                 ->label('Admin Roles')


### PR DESCRIPTION
This make it so you can add "root_admin" users again, without this you can't grant any privilege on the client area until #416 gets merged cause the legacy still checks for `Auth::user()->root_admin` not for `Auth::user()->can('resource permission')`.

https://github.com/pelican-dev/panel/issues/634#issuecomment-2416530074