### PR TITLE
Installer: fix argument types for `testConnection` & return type for `submit`

### DIFF
--- a/app/Filament/Pages/Installer/PanelInstaller.php
+++ b/app/Filament/Pages/Installer/PanelInstaller.php
@@ -25,6 +25,7 @@ use Filament\Pages\SimplePage;
 use Filament\Support\Enums\MaxWidth;
 use Filament\Support\Exceptions\Halt;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
@@ -94,7 +95,7 @@ class PanelInstaller extends SimplePage implements HasForms
         return 'data';
     }
 
-    public function submit(): RedirectResponse
+    public function submit(): Redirector|RedirectResponse
     {
         // Disable installer
         $this->writeToEnvironment(['APP_INSTALLED' => 'true']);

--- a/app/Filament/Pages/Installer/Steps/DatabaseStep.php
+++ b/app/Filament/Pages/Installer/Steps/DatabaseStep.php
@@ -72,7 +72,7 @@ class DatabaseStep
             });
     }
 
-    private static function testConnection(string $driver, string $host, string $port, string $database, string $username, string $password): bool
+    private static function testConnection(string $driver, ?string $host, null|string|int $port, ?string $database, ?string $username, ?string $password): bool
     {
         if ($driver === 'sqlite') {
             return true;

--- a/app/Filament/Pages/Installer/Steps/RedisStep.php
+++ b/app/Filament/Pages/Installer/Steps/RedisStep.php
@@ -56,7 +56,7 @@ class RedisStep
             });
     }
 
-    private static function testConnection(string $host, string $port, string $username, string $password): bool
+    private static function testConnection(string $host, null|string|int $port, ?string $username, ?string $password): bool
     {
         try {
             config()->set('database.redis._panel_install_test', [


### PR DESCRIPTION
Fixes `production.ERROR: App\Filament\Pages\Installer\Steps\DatabaseStep::testConnection(): Argument #2 ($host) must be of type string, null given` when using sqlite.

Fixes `production.ERROR: App\Filament\Pages\Installer\PanelInstaller::submit(): Return value must be of type Illuminate\Http\RedirectResponse, Livewire\Features\SupportRedirects\Redirector returned` when clicking "Finish".