### PR TITLE
Add back `trustedproxy` config

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    /*
+     * Set trusted proxy IP addresses.
+     *
+     * Both IPv4 and IPv6 addresses are
+     * supported, along with CIDR notation.
+     *
+     * The "*" character is syntactic sugar
+     * within TrustedProxy to trust any proxy
+     * that connects directly to your server,
+     * a requirement when you cannot know the address
+     * of your proxy (e.g. if using Rackspace balancers).
+     *
+     * The "**" character is syntactic sugar within
+     * TrustedProxy to trust not just any proxy that
+     * connects directly to your server, but also
+     * proxies that connect to those proxies, and all
+     * the way back until you reach the original source
+     * IP. It will mean that $request->getClientIp()
+     * always gets the originating client IP, no matter
+     * how many proxies that client's request has
+     * subsequently passed through.
+     */
+    'proxies' => in_array(env('TRUSTED_PROXIES', []), ['*', '**']) ?
+        env('TRUSTED_PROXIES') : explode(',', env('TRUSTED_PROXIES') ?? ''),
+];


### PR DESCRIPTION
This config is needed to make the `TRUSTED_PROXIES` env variable actually work.