### PR TITLE
Add UI for cpu pinning

### DIFF
--- a/app/Filament/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/CreateServer.php
@@ -685,6 +685,36 @@ class CreateServer extends CreateRecord
                                         ->columns(4)
                                         ->columnSpanFull()
                                         ->schema([
+                                            ToggleButtons::make('cpu_pinning')
+                                                ->label('CPU Pinning')->inlineLabel()->inline()
+                                                ->default(false)
+                                                ->afterStateUpdated(fn (Set $set) => $set('threads', []))
+                                                ->live()
+                                                ->options([
+                                                    false => 'Disabled',
+                                                    true => 'Enabled',
+                                                ])
+                                                ->colors([
+                                                    false => 'success',
+                                                    true => 'warning',
+                                                ])
+                                                ->columnSpan(2),
+
+                                            TagsInput::make('threads')
+                                                ->dehydratedWhenHidden()
+                                                ->hidden(fn (Get $get) => !$get('cpu_pinning'))
+                                                ->label('Pinned Threads')->inlineLabel()
+                                                ->required()
+                                                ->columnSpan(2)
+                                                ->separator()
+                                                ->splitKeys([','])
+                                                ->placeholder('Add pinned thread, e.g. 0 or 2-4'),
+                                        ]),
+
+                                    Grid::make()
+                                        ->columns(4)
+                                        ->columnSpanFull()
+                                        ->schema([
                                             ToggleButtons::make('oom_killer')
                                                 ->label('OOM Killer')
                                                 ->inlineLabel()->inline()

--- a/app/Filament/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/CreateServer.php
@@ -627,14 +627,24 @@ class CreateServer extends CreateRecord
                                                 ->minValue(0)
                                                 ->helperText('100% equals one CPU core.'),
                                         ]),
+                                ]),
 
+                            Fieldset::make('Advanced Limits')
+                                ->columnSpan(6)
+                                ->columns([
+                                    'default' => 1,
+                                    'sm' => 2,
+                                    'md' => 3,
+                                    'lg' => 3,
+                                ])
+                                ->schema([
                                     Grid::make()
                                         ->columns(4)
                                         ->columnSpanFull()
                                         ->schema([
                                             ToggleButtons::make('swap_support')
                                                 ->live()
-                                                ->label('Enable Swap Memory')
+                                                ->label('Swap Memory')
                                                 ->inlineLabel()
                                                 ->inline()
                                                 ->columnSpan(2)

--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -28,6 +28,7 @@ use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Tabs;
 use Filament\Forms\Components\Tabs\Tab;
+use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
@@ -318,6 +319,37 @@ class EditServer extends EditRecord
                                         Forms\Components\Hidden::make('io')
                                             ->helperText('The IO performance relative to other running containers')
                                             ->label('Block IO Proportion'),
+
+                                        Grid::make()
+                                            ->columns(4)
+                                            ->columnSpanFull()
+                                            ->schema([
+                                                ToggleButtons::make('cpu_pinning')
+                                                    ->label('CPU Pinning')->inlineLabel()->inline()
+                                                    ->default(false)
+                                                    ->afterStateUpdated(fn (Set $set) => $set('threads', []))
+                                                    ->formatStateUsing(fn (Get $get) => !empty($get('threads')))
+                                                    ->live()
+                                                    ->options([
+                                                        false => 'Disabled',
+                                                        true => 'Enabled',
+                                                    ])
+                                                    ->colors([
+                                                        false => 'success',
+                                                        true => 'warning',
+                                                    ])
+                                                    ->columnSpan(2),
+
+                                                TagsInput::make('threads')
+                                                    ->dehydratedWhenHidden()
+                                                    ->hidden(fn (Get $get) => !$get('cpu_pinning'))
+                                                    ->label('Pinned Threads')->inlineLabel()
+                                                    ->required()
+                                                    ->columnSpan(2)
+                                                    ->separator()
+                                                    ->splitKeys([','])
+                                                    ->placeholder('Add pinned thread, e.g. 0 or 2-4'),
+                                            ]),
 
                                         Grid::make()
                                             ->columns(4)

--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -24,6 +24,7 @@ use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Grid;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Tabs;
@@ -264,14 +265,23 @@ class EditServer extends EditRecord
                                                     ->numeric()
                                                     ->minValue(0),
                                             ]),
+                                    ]),
 
+                                Fieldset::make('Advanced Limits')
+                                    ->columns([
+                                        'default' => 1,
+                                        'sm' => 2,
+                                        'md' => 3,
+                                        'lg' => 3,
+                                    ])
+                                    ->schema([
                                         Grid::make()
                                             ->columns(4)
                                             ->columnSpanFull()
                                             ->schema([
                                                 ToggleButtons::make('swap_support')
                                                     ->live()
-                                                    ->label('Enable Swap Memory')->inlineLabel()->inline()
+                                                    ->label('Swap Memory')->inlineLabel()->inline()
                                                     ->columnSpan(2)
                                                     ->afterStateUpdated(function ($state, Set $set) {
                                                         $value = match ($state) {
@@ -316,7 +326,7 @@ class EditServer extends EditRecord
                                                     ->integer(),
                                             ]),
 
-                                        Forms\Components\Hidden::make('io')
+                                        Hidden::make('io')
                                             ->helperText('The IO performance relative to other running containers')
                                             ->label('Block IO Proportion'),
 


### PR DESCRIPTION
Although this is an feature not many people use there is no reason to hide features we already had.
Also, since we use toggle buttons now the risk of people misconfiguring cpu pinning is very low.

I also moved all the "advanced" settings into their own section:
![grafik](https://github.com/user-attachments/assets/103f600a-536f-4cba-b52a-057ebb375ffb)

CPU pinning is generally useful when having newer (intel) cpus that have E & P cores.