### PR TITLE
Fix `required` for pinned threads input

### DIFF
--- a/app/Filament/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/CreateServer.php
@@ -714,7 +714,7 @@ class CreateServer extends CreateRecord
                                                 ->dehydratedWhenHidden()
                                                 ->hidden(fn (Get $get) => !$get('cpu_pinning'))
                                                 ->label('Pinned Threads')->inlineLabel()
-                                                ->required()
+                                                ->required(fn (Get $get) => $get('cpu_pinning'))
                                                 ->columnSpan(2)
                                                 ->separator()
                                                 ->splitKeys([','])

--- a/app/Filament/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Resources/ServerResource/Pages/EditServer.php
@@ -354,7 +354,7 @@ class EditServer extends EditRecord
                                                     ->dehydratedWhenHidden()
                                                     ->hidden(fn (Get $get) => !$get('cpu_pinning'))
                                                     ->label('Pinned Threads')->inlineLabel()
-                                                    ->required()
+                                                    ->required(fn (Get $get) => $get('cpu_pinning'))
                                                     ->columnSpan(2)
                                                     ->separator()
                                                     ->splitKeys([','])


### PR DESCRIPTION
Followup fix for #652 

Pinned threads should only be `required` when cpu pinning is enabled.