### PR TITLE
Make sure the .env can be accessed by the webserver when running Docker

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -28,6 +28,7 @@ fi
 
 mkdir /pelican-data/database
 ln -s /pelican-data/.env /var/www/html/
+chown -h www-data:www-data /var/www/html/.env
 ln -s /pelican-data/database/database.sqlite /var/www/html/database/
 
 if ! grep -q "APP_KEY=" .env || grep -q "APP_KEY=$" .env; then


### PR DESCRIPTION
Fixes #629