### PR TITLE
Fixing Critical error on Webserver on Pelican Panel Docker Image

### DIFF
--- a/.github/docker/supervisord.conf
+++ b/.github/docker/supervisord.conf
@@ -1,5 +1,7 @@
 [unix_http_server]
 file=/tmp/supervisor.sock                       ; path to your socket file
+username=dummy
+password=dummy
 
 [supervisord]
 logfile=/var/log/supervisord/supervisord.log    ; supervisord log file
@@ -18,6 +20,8 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
 serverurl=unix:///tmp/supervisor.sock         ; use a unix:// URL  for a unix socket
+username=dummy
+password=dummy
 
 [program:php-fpm]
 command=/usr/local/sbin/php-fpm -F


### PR DESCRIPTION
Adding username and password dummy to get rid of critical error message

Fixing Issue mentioned at #629 

Explanation:
https://github.com/pelican-dev/panel/issues/629#issuecomment-2435733661