### PR TITLE
Add Port check when creating allocations

### DIFF
--- a/app/Filament/Resources/NodeResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Resources/NodeResource/RelationManagers/AllocationsRelationManager.php
@@ -139,7 +139,7 @@ class AllocationsRelationManager extends RelationManager
                                                 Notification::make()
                                                     ->title('Port Already Exists')
                                                     ->danger()
-                                                    ->body('Port ' . $portEntry . ' already exists.')
+                                                    ->body("Port $portEntry already exists.")
                                                     ->send();
                                             } else {
                                                 $ports->push($i);

--- a/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
@@ -8,7 +8,9 @@ use App\Services\Allocations\AssignmentService;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
 use Filament\Forms\Set;
+use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
@@ -93,18 +95,26 @@ class AllocationsRelationManager extends RelationManager
                             ->label('Ports')
                             ->inlineLabel()
                             ->live()
-                            ->afterStateUpdated(function ($state, Set $set) {
+                            ->afterStateUpdated(function ($state, Set $set, Get $get) {
                                 $ports = collect();
                                 $update = false;
                                 foreach ($state as $portEntry) {
                                     if (!str_contains($portEntry, '-')) {
                                         if (is_numeric($portEntry)) {
-                                            $ports->push((int) $portEntry);
+                                            if (Allocation::query()->where('ip', $get('allocation_ip'))->where('port', $portEntry)->exists()) {
+                                                Notification::make()
+                                                    ->title('Port Already Exists')
+                                                    ->danger()
+                                                    ->body('Port ' . $portEntry . ' already exists.')
+                                                    ->send();
+                                            } else {
+                                                $ports->push((int) $portEntry);
 
-                                            continue;
+                                                continue;
+                                            }
                                         }
 
-                                        // Do not add non numerical ports
+                                        // Do not add non-numerical ports
                                         $update = true;
 
                                         continue;
@@ -118,8 +128,19 @@ class AllocationsRelationManager extends RelationManager
 
                                     $start = max((int) $start, 0);
                                     $end = min((int) $end, 2 ** 16 - 1);
-                                    foreach (range($start, $end) as $i) {
-                                        $ports->push($i);
+                                    $range = $start <= $end ? range($start, $end) : range($end, $start);
+                                    foreach ($range as $i) {
+                                        if ($i > 1024 && $i <= 65535) {
+                                            if (Allocation::query()->where('ip', $get('allocation_ip'))->where('port', $portEntry)->exists()) {
+                                                Notification::make()
+                                                    ->title('Port Already Exists')
+                                                    ->danger()
+                                                    ->body('Port ' . $portEntry . ' already exists.')
+                                                    ->send();
+                                            } else {
+                                                $ports->push($i);
+                                            }
+                                        }
                                     }
                                 }
 
@@ -134,8 +155,6 @@ class AllocationsRelationManager extends RelationManager
                                     $update = true;
                                     $ports = $sortedPorts;
                                 }
-
-                                $ports = $ports->filter(fn ($port) => $port > 1024 && $port < 65535)->values();
 
                                 if ($update) {
                                     $set('allocation_ports', $ports->all());


### PR DESCRIPTION
Will check the allocations for the given ip and the given ports to see if they already exist in the database, if they do they're removed from the tag list, and a notification is sent telling the user that the port already exists. 
![chrome_tA1ubW5I2s](https://github.com/user-attachments/assets/c7de9ec5-c662-4636-9d82-ceee9d230520)

This is applied to all three places where you can create an allocation.



Closes https://github.com/pelican-dev/panel/issues/655