### PR TITLE
Adding fix for forks to use a variable for Docker image reference instead of hard String

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,10 @@ on:
     types:
       - published
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build-and-push:
     name: Build and Push
@@ -26,7 +30,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/pelican-dev/panel
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=false
           tags: |


### PR DESCRIPTION
Adding fix for forks to use a variable for Docker image reference instead of hard String

Source of information:
https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images

This is just changing the docker image publish to publish an image to the repository the workflow is running at.
It allows fork of the repository to publish their own images to the accourding fork registry. Instead that every single workflow tries to push into the pelican-dev/panel repo and get a not authorized error.