### PR TITLE
Allow path in Connection Address

### DIFF
--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -93,7 +93,7 @@ class CreateNode extends CreateRecord
                                     $fqdn = array_get($url, 'host', $state);
                                     $scheme = array_get($url, 'scheme', 'https');
                                     $validRecords = gethostbynamel(array_get(parse_url("$scheme://$fqdn"), 'host'));
-                                    
+
                                     if ($validRecords) {
                                         $set('dns', true);
 

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -89,10 +89,7 @@ class CreateNode extends CreateRecord
                                         return;
                                     }
 
-                                    $url = parse_url($state);
-                                    $fqdn = array_get($url, 'host', $state);
-                                    $scheme = array_get($url, 'scheme', 'https');
-                                    $validRecords = gethostbynamel(array_get(parse_url("$scheme://$fqdn"), 'host'));
+                                    $validRecords = gethostbynamel(array_get(parse_url("http://$state"), 'host', $state));
 
                                     if ($validRecords) {
                                         $set('dns', true);

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -89,7 +89,7 @@ class CreateNode extends CreateRecord
                                         return;
                                     }
 
-                                    $scheme = $get('scheme') ?? "http";
+                                    $scheme = $get('scheme') ?? 'http';
                                     $validRecords = gethostbynamel(array_get(parse_url("$scheme://$state"), 'host', $state));
 
                                     if ($validRecords) {

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -74,7 +74,7 @@ class CreateNode extends CreateRecord
 
                                     return '';
                                 })
-                                ->afterStateUpdated(function (Set $set, ?string $state) {
+                                ->afterStateUpdated(function (Set $set, Get $get, ?string $state) {
                                     $set('dns', null);
                                     $set('ip', null);
 
@@ -89,7 +89,8 @@ class CreateNode extends CreateRecord
                                         return;
                                     }
 
-                                    $validRecords = gethostbynamel(array_get(parse_url("http://$state"), 'host', $state));
+                                    $scheme = $get('scheme') ?? "http";
+                                    $validRecords = gethostbynamel(array_get(parse_url("$scheme://$state"), 'host', $state));
 
                                     if ($validRecords) {
                                         $set('dns', true);

--- a/app/Filament/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/CreateNode.php
@@ -89,7 +89,11 @@ class CreateNode extends CreateRecord
                                         return;
                                     }
 
-                                    $validRecords = gethostbynamel($state);
+                                    $url = parse_url($state);
+                                    $fqdn = array_get($url, 'host', $state);
+                                    $scheme = array_get($url, 'scheme', 'https');
+                                    $validRecords = gethostbynamel(array_get(parse_url("$scheme://$fqdn"), 'host'));
+                                    
                                     if ($validRecords) {
                                         $set('dns', true);
 

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -121,7 +121,11 @@ class EditNode extends EditRecord
                                         return;
                                     }
 
-                                    $validRecords = gethostbynamel($state);
+                                    $url = parse_url($state);
+                                    $fqdn = array_get($url, 'host', $state);
+                                    $scheme = array_get($url, 'scheme', 'https');
+                                    $validRecords = gethostbynamel(array_get(parse_url("$scheme://$fqdn"), 'host'));
+
                                     if ($validRecords) {
                                         $set('dns', true);
 
@@ -548,11 +552,12 @@ class EditNode extends EditRecord
     protected function mutateFormDataBeforeFill(array $data): array
     {
         $node = Node::findOrFail($data['id']);
+        $fqdn = array_get($node->parseFQDN(), 'host');
 
         $data['config'] = $node->getYamlConfiguration();
 
-        if (!is_ip($node->fqdn)) {
-            $validRecords = gethostbynamel($node->fqdn);
+        if (!is_ip($fqdn)) {
+            $validRecords = gethostbynamel($fqdn);
             if ($validRecords) {
                 $data['dns'] = true;
                 $data['ip'] = collect($validRecords)->first();

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -121,10 +121,7 @@ class EditNode extends EditRecord
                                         return;
                                     }
 
-                                    $url = parse_url($state);
-                                    $fqdn = array_get($url, 'host', $state);
-                                    $scheme = array_get($url, 'scheme', 'https');
-                                    $validRecords = gethostbynamel(array_get(parse_url("$scheme://$fqdn"), 'host'));
+                                    $validRecords = gethostbynamel(array_get(parse_url("http://$state"), 'host', $state));
 
                                     if ($validRecords) {
                                         $set('dns', true);

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -121,7 +121,7 @@ class EditNode extends EditRecord
                                         return;
                                     }
 
-                                    $scheme = $get('scheme') ?? "http";
+                                    $scheme = $get('scheme') ?? 'http';
                                     $validRecords = gethostbynamel(array_get(parse_url("$scheme://$state"), 'host', $state));
 
                                     if ($validRecords) {

--- a/app/Filament/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Resources/NodeResource/Pages/EditNode.php
@@ -106,7 +106,7 @@ class EditNode extends EditRecord
 
                                     return '';
                                 })
-                                ->afterStateUpdated(function (Set $set, ?string $state) {
+                                ->afterStateUpdated(function (Set $set, Get $get, ?string $state) {
                                     $set('dns', null);
                                     $set('ip', null);
 
@@ -121,7 +121,8 @@ class EditNode extends EditRecord
                                         return;
                                     }
 
-                                    $validRecords = gethostbynamel(array_get(parse_url("http://$state"), 'host', $state));
+                                    $scheme = $get('scheme') ?? "http";
+                                    $validRecords = gethostbynamel(array_get(parse_url("$scheme://$state"), 'host', $state));
 
                                     if ($validRecords) {
                                         $set('dns', true);

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -165,23 +165,26 @@ class Node extends Model
     /**
      * Parses the FQDN and returns the host and path.
      */
-    public function parseFQDN(): array {
+    public function parseFQDN(): array
+    {
         $fqdn = array_get(parse_url($this->fqdn), 'host', $this->fqdn);
         $url = parse_url("$this->scheme://$fqdn");
 
         return [
             'host' => array_get($url, 'host', $fqdn),
-            'path' => array_get($url, 'path', '')
+            'path' => array_get($url, 'path', ''),
         ];
     }
 
     /**
      * Get the connection address to use when making calls to this node.
      */
-    public function getConnectionAddress(): string {
+    public function getConnectionAddress(): string
+    {
         $parsedFQDN = $this->parseFQDN();
         $host = array_get($parsedFQDN, 'host');
         $path = array_get($parsedFQDN, 'path');
+
         return "$this->scheme://$host:$this->daemon_listen$path";
     }
 
@@ -383,7 +386,7 @@ class Node extends Model
         return cache()->remember("nodes.$this->id.ips", now()->addHour(), function () {
             $ips = collect();
             $fqdn = array_get($this->parseFQDN(), 'host');
-            
+
             if (is_ip($fqdn)) {
                 $ips = $ips->push($fqdn);
             } elseif ($dnsRecords = gethostbynamel($fqdn)) {

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -163,12 +163,25 @@ class Node extends Model
     }
 
     /**
+     * Parses the FQDN and returns the host and path.
+     */
+    public function parseFQDN(): array
+    {
+        $url = parse_url("$this->scheme://$this->fqdn");
+
+        return [
+            'host' => array_get($url, 'host', $this->fqdn),
+            'path' => array_get($url, 'path', ''),
+        ];
+    }
+
+    /**
      * Get the connection address to use when making calls to this node.
      */
     public function getConnectionAddress(): string
     {
-        $url = parse_url("$this->scheme://$this->fqdn");
-        $host = array_get($url, 'host', $this->fqdn);
+        $url = $this->parseFQDN();
+        $host = array_get($url, 'host');
         $path = array_get($url, 'path');
 
         return "$this->scheme://$host:$this->daemon_listen$path";

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -163,27 +163,13 @@ class Node extends Model
     }
 
     /**
-     * Parses the FQDN and returns the host and path.
-     */
-    public function parseFQDN(): array
-    {
-        $fqdn = array_get(parse_url($this->fqdn), 'host', $this->fqdn);
-        $url = parse_url("$this->scheme://$fqdn");
-
-        return [
-            'host' => array_get($url, 'host', $fqdn),
-            'path' => array_get($url, 'path', ''),
-        ];
-    }
-
-    /**
      * Get the connection address to use when making calls to this node.
      */
     public function getConnectionAddress(): string
     {
-        $parsedFQDN = $this->parseFQDN();
-        $host = array_get($parsedFQDN, 'host');
-        $path = array_get($parsedFQDN, 'path');
+        $url = parse_url("$this->scheme://$this->fqdn");
+        $host = array_get($url, 'host', $this->fqdn);
+        $path = array_get($url, 'path');
 
         return "$this->scheme://$host:$this->daemon_listen$path";
     }

--- a/app/Transformers/Api/Client/ServerTransformer.php
+++ b/app/Transformers/Api/Client/ServerTransformer.php
@@ -45,7 +45,7 @@ class ServerTransformer extends BaseClientTransformer
             'node' => $server->node->name,
             'is_node_under_maintenance' => $server->node->isUnderMaintenance(),
             'sftp_details' => [
-                'ip' => $server->node->fqdn,
+                'ip' => array_get($server->node->parseFQDN(), 'host'),
                 'alias' => $server->node->daemon_sftp_alias,
                 'port' => $server->node->daemon_sftp,
             ],


### PR DESCRIPTION
Currently, if the connection address has a path, the port will end up after the path.
![001150 Zen Browser 2024-10-27 16 41 06](https://github.com/user-attachments/assets/0a54d467-20bb-456f-b985-71927afd619d)

![001152 Zen Browser 2024-10-27 20 58 48](https://github.com/user-attachments/assets/c115d5ac-5ea8-45e3-9b69-3e002c7c44b5)

![001154 Zen Browser 2024-10-27 20 59 50](https://github.com/user-attachments/assets/df8a7f1f-997d-44d5-b28c-c7c299aeea13)

This PR ensures the path comes after the port.
![001146 Zen Browser 2024-10-27 16 39 58](https://github.com/user-attachments/assets/f026829f-29ad-4b43-ab1d-2edbd7288418)

![001132 Zen Browser 2024-10-27 15 55 48](https://github.com/user-attachments/assets/e7c30df2-2c90-4eb2-8136-83d75b786482)

![001156 Zen Browser 2024-10-27 21 00 18](https://github.com/user-attachments/assets/53be3d53-e3ee-4be2-bfac-335979c64032)
