### PR TITLE
Fix adding allocations that are already in use.

### DIFF
--- a/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
@@ -149,7 +149,7 @@ class AllocationsRelationManager extends RelationManager
                     ->multiple()
                     ->associateAnother(false)
                     ->preloadRecordSelect()
-                    ->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo($this->getOwnerRecord()->node))
+                    ->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo($this->getOwnerRecord()->node)->whereNull('server_id'))
                     ->label('Add Allocation'),
             ])
             ->bulkActions([


### PR DESCRIPTION
Add where null to not include allocations already assigned to a server.

Closes #679 