### PR TITLE
Write special env variables at the very end of the installer

### DIFF
--- a/app/Filament/Pages/Installer/PanelInstaller.php
+++ b/app/Filament/Pages/Installer/PanelInstaller.php
@@ -71,7 +71,7 @@ class PanelInstaller extends SimplePage implements HasForms
                 EnvironmentStep::make($this),
                 DatabaseStep::make($this),
                 RedisStep::make($this)
-                    ->hidden(fn (Get $get) => $get('env_general.SESSION_DRIVER') != 'redis' && $get('env_general.QUEUE_CONNECTION') != 'redis' && $get('env_general.CACHE_STORE') != 'redis'),
+                    ->hidden(fn (Get $get) => $get('env_special.SESSION_DRIVER') != 'redis' && $get('env_general.QUEUE_CONNECTION') != 'redis' && $get('env_general.CACHE_STORE') != 'redis'),
                 AdminUserStep::make($this),
                 CompletedStep::make(),
             ])

--- a/app/Filament/Pages/Installer/PanelInstaller.php
+++ b/app/Filament/Pages/Installer/PanelInstaller.php
@@ -104,6 +104,9 @@ class PanelInstaller extends SimplePage implements HasForms
         $this->user ??= User::all()->filter(fn ($user) => $user->isRootAdmin())->first();
         auth()->guard()->login($this->user, true);
 
+        // Special handling for special env variables (looking at you, SESSION_DRIVER)
+        $this->writeToEnv('env_special');
+
         // Redirect to admin panel
         return redirect(Dashboard::getUrl());
     }

--- a/app/Filament/Pages/Installer/Steps/EnvironmentStep.php
+++ b/app/Filament/Pages/Installer/Steps/EnvironmentStep.php
@@ -68,7 +68,7 @@ class EnvironmentStep
                     ->inline()
                     ->options(self::CACHE_DRIVERS)
                     ->default(config('cache.default', 'file')),
-                ToggleButtons::make('env_general.SESSION_DRIVER')
+                ToggleButtons::make('env_special.SESSION_DRIVER')
                     ->label('Session Driver')
                     ->hintIcon('tabler-question-mark')
                     ->hintIconTooltip('The driver used for storing sessions. We recommend "Filesystem" or "Database".')

--- a/database/migrations/2024_07_19_130942_create_permission_tables.php
+++ b/database/migrations/2024_07_19_130942_create_permission_tables.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
@@ -114,10 +114,6 @@ return new class extends Migration
 
             $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
         });
-
-        app('cache')
-            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
-            ->forget(config('permission.cache.key'));
     }
 
     /**


### PR DESCRIPTION
Closes #696

This makes sure that "special" env variables (in this case the `SESSION_DRIVER`) are only written to the .env file at the very end of the installer.
The `SESSION_DRIVER` variable is the only variable that directly affects the installer when being changed.