### PR TITLE
Fixing Docker Environment variable only getting checked for existence instead of value

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -52,11 +52,11 @@ crond -L /var/log/crond -l 5
 export SUPERVISORD_CADDY=false
 
 ## disable caddy if SKIP_CADDY is set
-if [[ -z $SKIP_CADDY ]]; then
+if [[ "$SKIP_CADDY" == "true" ]];
+  echo "Starting PHP-FPM only"
+else
   echo "Starting PHP-FPM and Caddy"
   export SUPERVISORD_CADDY=true
-else
-  echo "Starting PHP-FPM only"
 fi
 
 chown -R www-data:www-data /pelican-data/.env /pelican-data/database

--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -52,7 +52,7 @@ crond -L /var/log/crond -l 5
 export SUPERVISORD_CADDY=false
 
 ## disable caddy if SKIP_CADDY is set
-if [[ "$SKIP_CADDY" == "true" ]];
+if [[ "$SKIP_CADDY:-" == "true" ]];
   echo "Starting PHP-FPM only"
 else
   echo "Starting PHP-FPM and Caddy"

--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -52,7 +52,7 @@ crond -L /var/log/crond -l 5
 export SUPERVISORD_CADDY=false
 
 ## disable caddy if SKIP_CADDY is set
-if [[ "$SKIP_CADDY:-" == "true" ]];
+if [[ "${SKIP_CADDY:-}" == "true" ]]; then
   echo "Starting PHP-FPM only"
 else
   echo "Starting PHP-FPM and Caddy"


### PR DESCRIPTION
This is fixing possible misinterpretations of the provided docker compose file.
It was only checking for the existence of the environment variable „SKIP_CADDY“ instead of checking for its value.

Now it‘s making sure that the Environment variable is actually set to true so if a value like false is set, caddy will still be active.
