### PR TITLE
Improve egg import error handling

### DIFF
--- a/app/Filament/Resources/EggResource/Pages/ListEggs.php
+++ b/app/Filament/Resources/EggResource/Pages/ListEggs.php
@@ -142,6 +142,7 @@ class ListEggs extends ListRecords
                             } catch (Exception $exception) {
                                 Notification::make()
                                     ->title('Import Failed')
+                                    ->body($exception->getMessage())
                                     ->danger()
                                     ->send();
 
@@ -158,6 +159,7 @@ class ListEggs extends ListRecords
                         } catch (Exception $exception) {
                             Notification::make()
                                 ->title('Import Failed')
+                                ->body($exception->getMessage())
                                 ->danger()
                                 ->send();
 

--- a/app/Services/Eggs/Sharing/EggImporterService.php
+++ b/app/Services/Eggs/Sharing/EggImporterService.php
@@ -86,7 +86,9 @@ class EggImporterService
         $tmpDir = TemporaryDirectory::make()->deleteWhenDestroyed();
         $tmpPath = $tmpDir->path($info['basename']);
 
-        file_put_contents($tmpPath, file_get_contents($url));
+        if (!file_put_contents($tmpPath, file_get_contents($url))) {
+            throw new InvalidFileUploadException('Could not write temporary file.');
+        }
 
         return $this->fromFile(new UploadedFile($tmpPath, $info['basename'], 'application/json'), $egg);
     }
@@ -94,7 +96,6 @@ class EggImporterService
     /**
      * Takes an uploaded file and parses out the egg configuration from within.
      *
-     * @throws \JsonException
      * @throws \App\Exceptions\Service\InvalidFileUploadException
      */
     protected function parseFile(UploadedFile $file): array
@@ -103,7 +104,11 @@ class EggImporterService
             throw new InvalidFileUploadException('The selected file was not uploaded successfully');
         }
 
-        $parsed = json_decode($file->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        try {
+            $parsed = json_decode($file->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new InvalidFileUploadException('Could not read JSON file: ' . $exception->getMessage());
+        }
 
         $version = $parsed['meta']['version'] ?? '';
 


### PR DESCRIPTION
- Make sure `file_put_contents` was successful.
- Throw `InvalidFileUploadException` instead of `JsonException` when `json_decode` fails.
- Show exception message in notification.