### PR TITLE
Make sure UTC is always used internally

### DIFF
--- a/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
+++ b/app/Filament/Resources/ApiKeyResource/Pages/ListApiKeys.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\ApiKeyResource\Pages;
 
 use App\Filament\Resources\ApiKeyResource;
 use App\Models\ApiKey;
+use App\Tables\Columns\DateTimeColumn;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Actions\CreateAction;
@@ -35,15 +36,13 @@ class ListApiKeys extends ListRecords
                     ->hidden()
                     ->searchable(),
 
-                TextColumn::make('last_used_at')
+                DateTimeColumn::make('last_used_at')
                     ->label('Last Used')
                     ->placeholder('Not Used')
-                    ->dateTime()
                     ->sortable(),
 
-                TextColumn::make('created_at')
+                DateTimeColumn::make('created_at')
                     ->label('Created')
-                    ->dateTime()
                     ->sortable(),
 
                 TextColumn::make('user.username')

--- a/app/Filament/Resources/DatabaseHostResource/RelationManagers/DatabasesRelationManager.php
+++ b/app/Filament/Resources/DatabaseHostResource/RelationManagers/DatabasesRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\DatabaseHostResource\RelationManagers;
 
 use App\Models\Database;
 use App\Services\Databases\DatabasePasswordService;
+use App\Tables\Columns\DateTimeColumn;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -54,7 +55,7 @@ class DatabasesRelationManager extends RelationManager
                     ->icon('tabler-brand-docker')
                     ->url(fn (Database $database) => route('filament.admin.resources.servers.edit', ['record' => $database->server_id])),
                 TextColumn::make('max_connections'),
-                TextColumn::make('created_at')->dateTime(),
+                DateTimeColumn::make('created_at'),
             ])
             ->actions([
                 DeleteAction::make(),

--- a/app/Filament/Resources/DatabaseResource/Pages/ListDatabases.php
+++ b/app/Filament/Resources/DatabaseResource/Pages/ListDatabases.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\DatabaseResource\Pages;
 
 use App\Filament\Resources\DatabaseResource;
+use App\Tables\Columns\DateTimeColumn;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Actions\BulkActionGroup;
@@ -34,12 +35,10 @@ class ListDatabases extends ListRecords
                 TextColumn::make('max_connections')
                     ->numeric()
                     ->sortable(),
-                TextColumn::make('created_at')
-                    ->dateTime()
+                DateTimeColumn::make('created_at')
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
-                TextColumn::make('updated_at')
-                    ->dateTime()
+                DateTimeColumn::make('updated_at')
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -2,11 +2,7 @@
 
 namespace App\Models;
 
-use Carbon\CarbonInterface;
-use DateTimeInterface;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Container\Container;
@@ -16,7 +12,6 @@ use App\Exceptions\Model\DataValidationException;
 use Illuminate\Database\Eloquent\Model as IlluminateModel;
 use Illuminate\Validation\Factory as ValidationFactory;
 use Illuminate\Validation\Validator;
-use InvalidArgumentException;
 
 abstract class Model extends IlluminateModel
 {
@@ -67,36 +62,6 @@ abstract class Model extends IlluminateModel
     public function getRouteKeyName(): string
     {
         return 'uuid';
-    }
-
-    protected function asDateTime($value): Carbon
-    {
-        $timezone = auth()->user()?->timezone ?? config('app.timezone', 'UTC');
-
-        if ($value instanceof CarbonInterface) {
-            return Date::instance($value->timezone($timezone));
-        }
-
-        if ($value instanceof DateTimeInterface) {
-            return Date::parse($value->format('Y-m-d H:i:s.u'), $timezone);
-        }
-
-        if (is_numeric($value)) {
-            return Date::createFromTimestamp($value, $timezone);
-        }
-
-        if ($this->isStandardDateFormat($value)) {
-            return Date::instance(Carbon::createFromFormat('Y-m-d', $value)->timezone($timezone)->startOfDay());
-        }
-
-        $format = $this->getDateFormat();
-        try {
-            $date = Date::createFromFormat($format, $value)->timezone($timezone);
-        } catch (InvalidArgumentException) {
-            $date = false;
-        }
-
-        return $date ?: Date::parse($value);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -213,9 +213,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     {
         $rules = parent::getRules();
 
-        $rules['language'][] = new In(array_keys((new self)->getAvailableLanguages()));
+        $rules['language'][] = new In(array_keys((new self())->getAvailableLanguages()));
         $rules['timezone'][] = new In(array_values(DateTimeZone::listIdentifiers()));
-        $rules['username'][] = new Username;
+        $rules['username'][] = new Username();
 
         return $rules;
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -188,6 +188,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         static::creating(function (self $user) {
             $user->uuid = Str::uuid()->toString();
 
+            $user->timezone = env('APP_TIMEZONE', 'UTC');
+
             return true;
         });
 
@@ -211,9 +213,9 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     {
         $rules = parent::getRules();
 
-        $rules['language'][] = new In(array_keys((new self())->getAvailableLanguages()));
+        $rules['language'][] = new In(array_keys((new self)->getAvailableLanguages()));
         $rules['timezone'][] = new In(array_values(DateTimeZone::listIdentifiers()));
-        $rules['username'][] = new Username();
+        $rules['username'][] = new Username;
 
         return $rules;
     }

--- a/app/Tables/Columns/DateTimeColumn.php
+++ b/app/Tables/Columns/DateTimeColumn.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Tables\Columns;
+
+use Filament\Tables\Columns\TextColumn;
+
+class DateTimeColumn extends TextColumn
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dateTime(timezone: auth()->user()?->timezone ?? config('app.timezone', 'UTC'));
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -7,6 +7,8 @@ return [
 
     'version' => 'canary',
 
+    'timezone' => 'UTC',
+
     'exceptions' => [
         'report_all' => env('APP_REPORT_ALL_EXCEPTIONS', false),
     ],


### PR DESCRIPTION
The backend should _always_ use UTC to avoid timezone problems.
On the (filament) frontend dates should be translated from UTC to the users timezone.

`APP_TIMEZONE` env variable is now only used as default timezone for new users.