### PR TITLE
Fix permission check if user is subuser and admin

### DIFF
--- a/app/Policies/ServerPolicy.php
+++ b/app/Policies/ServerPolicy.php
@@ -28,8 +28,8 @@ class ServerPolicy
 
         $subuser = $server->subusers->where('user_id', $user->id)->first();
         // If the user is a subuser check their permissions
-        if ($subuser) {
-            return in_array($ability, $subuser->permissions);
+        if ($subuser && in_array($ability, $subuser->permissions)) {
+            return true;
         }
 
         // Return null to let default policies take over


### PR DESCRIPTION
If a user is a subuser and has an admin role it previously only checked the subuser permissions.
Now it first checks for the subuser permission, then the admin role permissions.