### PR TITLE
Remove `exception` methods because of memory bombing

### DIFF
--- a/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
+use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Model;
 use PDOException;
 
@@ -113,7 +114,7 @@ class CreateDatabaseHost extends CreateRecord
                 ->danger()
                 ->send();
 
-            $this->halt();
+            throw new Halt();
         }
     }
 }

--- a/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
@@ -113,7 +113,7 @@ class CreateDatabaseHost extends CreateRecord
                 ->danger()
                 ->send();
 
-            return null;
+            $this->halt();
         }
     }
 }

--- a/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/CreateDatabaseHost.php
@@ -4,8 +4,6 @@ namespace App\Filament\Resources\DatabaseHostResource\Pages;
 
 use App\Filament\Resources\DatabaseHostResource;
 use App\Services\Databases\Hosts\HostCreationService;
-use Closure;
-use Exception;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -104,21 +102,18 @@ class CreateDatabaseHost extends CreateRecord
 
     protected function handleRecordCreation(array $data): Model
     {
-        return $this->service->handle($data);
-    }
-
-    public function exception(Exception $e, Closure $stopPropagation): void
-    {
-        if ($e instanceof PDOException) {
+        try {
+            return $this->service->handle($data);
+        } catch (PDOException $exception) {
             Notification::make()
                 ->title('Error connecting to database host')
-                ->body($e->getMessage())
+                ->body($exception->getMessage())
                 ->color('danger')
                 ->icon('tabler-database')
                 ->danger()
                 ->send();
 
-            $stopPropagation();
+            return null;
         }
     }
 }

--- a/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
@@ -126,7 +126,7 @@ class EditDatabaseHost extends EditRecord
                 ->danger()
                 ->send();
 
-            return $record;
+            $this->halt();
         }
     }
 }

--- a/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
@@ -6,8 +6,6 @@ use App\Filament\Resources\DatabaseHostResource;
 use App\Filament\Resources\DatabaseHostResource\RelationManagers\DatabasesRelationManager;
 use App\Models\DatabaseHost;
 use App\Services\Databases\Hosts\HostUpdateService;
-use Closure;
-use Exception;
 use Filament\Actions;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
@@ -117,21 +115,18 @@ class EditDatabaseHost extends EditRecord
             return $record;
         }
 
-        return $this->hostUpdateService->handle($record, $data);
-    }
-
-    public function exception(Exception $e, Closure $stopPropagation): void
-    {
-        if ($e instanceof PDOException) {
+        try {
+            return $this->hostUpdateService->handle($record, $data);
+        } catch (PDOException $exception) {
             Notification::make()
                 ->title('Error connecting to database host')
-                ->body($e->getMessage())
+                ->body($exception->getMessage())
                 ->color('danger')
                 ->icon('tabler-database')
                 ->danger()
                 ->send();
 
-            $stopPropagation();
+            return $record;
         }
     }
 }

--- a/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
@@ -14,6 +14,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Model;
 use PDOException;
 
@@ -126,7 +127,7 @@ class EditDatabaseHost extends EditRecord
                 ->danger()
                 ->send();
 
-            $this->halt();
+            throw new Halt();
         }
     }
 }

--- a/app/Filament/Resources/UserResource/Pages/EditProfile.php
+++ b/app/Filament/Resources/UserResource/Pages/EditProfile.php
@@ -361,7 +361,7 @@ class EditProfile extends \Filament\Pages\Auth\EditProfile
                     ->danger()
                     ->send();
 
-                return $record;
+                $this->halt();
             }
 
             cache()->forget("users.$record->id.2fa.state");

--- a/app/Filament/Resources/UserResource/Pages/EditProfile.php
+++ b/app/Filament/Resources/UserResource/Pages/EditProfile.php
@@ -30,6 +30,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Get;
 use Filament\Notifications\Notification;
 use Filament\Support\Enums\MaxWidth;
+use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
@@ -361,7 +362,7 @@ class EditProfile extends \Filament\Pages\Auth\EditProfile
                     ->danger()
                     ->send();
 
-                $this->halt();
+                throw new Halt();
             }
 
             cache()->forget("users.$record->id.2fa.state");


### PR DESCRIPTION
Fixes #732

(ref https://github.com/pelican-dev/panel/pull/502/commits/6067076ec46db5b2c9175e206ea59683f690cbac)