### PR TITLE
Fix timezone for file timestamps

### DIFF
--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -146,8 +146,8 @@ class File extends Model
             return array_map(function ($file) {
                 return [
                     'name' => $file['name'],
-                    'created_at' => Carbon::parse($file['created']),
-                    'modified_at' => Carbon::parse($file['modified']),
+                    'created_at' => Carbon::parse($file['created'])->timezone('UTC'),
+                    'modified_at' => Carbon::parse($file['modified'])->timezone('UTC'),
                     'mode' => $file['mode'],
                     'mode_bits' => (int) $file['mode_bits'],
                     'size' => (int) $file['size'],


### PR DESCRIPTION
Make sure the file timestamps are stored as UTC so they can be translated to the user timezone correctly.

_Example with `Europe/Berlin` system timezone._
Before:
![grafik](https://github.com/user-attachments/assets/895d0c49-7c62-41b3-ae76-f0947e4e593e)

After:
![grafik](https://github.com/user-attachments/assets/b2615e4c-423d-4251-94fa-927bdc7176f8)