### PR TITLE
Hide sidebar on server list

### DIFF
--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -33,7 +33,7 @@ class AppPanelProvider extends PanelProvider
             ->brandLogo(config('app.logo'))
             ->brandLogoHeight('2rem')
             ->favicon(config('app.favicon', '/pelican.ico'))
-            ->topNavigation(config('panel.filament.top-navigation', true))
+            ->navigation(false)
             ->maxContentWidth(MaxWidth::ScreenTwoExtraLarge)
             ->profile(EditProfile::class, false)
             ->login(Login::class)


### PR DESCRIPTION
Disables navigation on the server list to make sure the content is centered.

Before:
![image](https://github.com/user-attachments/assets/aeefec2c-ec4e-4016-a4db-4a08f4bc97a2)

After:
![image](https://github.com/user-attachments/assets/62634713-dedb-4db1-bd70-56f1c4c3b571)