### PR TITLE
Add filters to server list

### DIFF
--- a/app/Filament/App/Resources/ServerResource/Pages/ListServers.php
+++ b/app/Filament/App/Resources/ServerResource/Pages/ListServers.php
@@ -9,7 +9,9 @@ use App\Tables\Columns\ServerEntryColumn;
 use Carbon\CarbonInterface;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Columns\Layout\Stack;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Number;
 
@@ -36,7 +38,22 @@ class ListServers extends ListRecords
             ->recordUrl(fn (Server $server) => Console::getUrl(panel: 'server', tenant: $server))
             ->emptyStateIcon('tabler-brand-docker')
             ->emptyStateDescription('')
-            ->emptyStateHeading('You don\'t have access to any servers!');
+            ->emptyStateHeading('You don\'t have access to any servers!')
+            ->filters([
+                SelectFilter::make('owner')
+                    ->default('my')
+                    ->options([
+                        'my' => 'My Servers',
+                        'other' => 'Others\' Servers',
+                    ])
+                    ->query(function (Builder $query, $state) {
+                        return match ($state['value']) {
+                            'my' => $query->where('owner_id', auth()->user()->id),
+                            'other' => $query->whereNot('owner_id', auth()->user()->id),
+                            default => $query,
+                        };
+                    }),
+            ]);
     }
 
     // @phpstan-ignore-next-line

--- a/app/Filament/App/Resources/ServerResource/Pages/ListServers.php
+++ b/app/Filament/App/Resources/ServerResource/Pages/ListServers.php
@@ -21,9 +21,11 @@ class ListServers extends ListRecords
 
     public function table(Table $table): Table
     {
+        $baseQuery = auth()->user()->can('viewList server') ? Server::query() : auth()->user()->accessibleServers();
+
         return $table
             ->paginated(false)
-            ->query(fn () => auth()->user()->can('viewList server') ? Server::query() : auth()->user()->accessibleServers())
+            ->query(fn () => $baseQuery)
             ->poll('15s')
             ->columns([
                 Stack::make([
@@ -53,6 +55,10 @@ class ListServers extends ListRecords
                             default => $query,
                         };
                     }),
+                SelectFilter::make('egg')
+                    ->relationship('egg', 'name', fn (Builder $query) => $query->whereIn('id', $baseQuery->pluck('egg_id')))
+                    ->searchable()
+                    ->preload(),
             ]);
     }
 


### PR DESCRIPTION
Adds two filters to the server list: `Owned by` and `Egg`.

The egg filter is pretty self explanatory.
Only "special" thing here is that the selection is prefiltered. So you can only select eggs that you have servers of. In my example I only have a Paper server and a Garry's Mod server so the selection is prefiltered to only these two options.
![image](https://github.com/user-attachments/assets/41f59b2b-bff5-44fa-a12d-011cce444900)
![image](https://github.com/user-attachments/assets/06565a8b-ec61-49b9-9705-ea0721b7f96a)

`Owned by` is like the toggle in the old client area, but it also has a state for "All servers".
By default it filters by "My servers".
![image](https://github.com/user-attachments/assets/ff40ade0-188c-496d-8000-54424daa45ec)
![image](https://github.com/user-attachments/assets/a374f2f9-2036-4dc5-8368-dc82a5389bb2)
![image](https://github.com/user-attachments/assets/5bd35ffc-b7e7-4534-8397-cfc30c90d029)