### PR TITLE
Show full client api key after creation

### DIFF
--- a/app/Filament/Resources/UserResource/Pages/EditProfile.php
+++ b/app/Filament/Resources/UserResource/Pages/EditProfile.php
@@ -272,7 +272,7 @@ class EditProfile extends BaseEditProfile
                                             ])->headerActions([
                                                 Action::make('Create')
                                                     ->disabled(fn (Get $get) => $get('description') === null)
-                                                    ->successRedirectUrl(route('filament.admin.auth.profile', ['tab' => '-api-keys-tab']))
+                                                    ->successRedirectUrl(self::getUrl(['tab' => '-api-keys-tab']))
                                                     ->action(function (Get $get, Action $action, User $user) {
                                                         $token = $user->createToken(
                                                             $get('description'),

--- a/app/Filament/Resources/UserResource/Pages/EditProfile.php
+++ b/app/Filament/Resources/UserResource/Pages/EditProfile.php
@@ -278,10 +278,19 @@ class EditProfile extends BaseEditProfile
                                                             $get('description'),
                                                             $get('allowed_ips'),
                                                         );
+
                                                         Activity::event('user:api-key.create')
                                                             ->subject($token->accessToken)
                                                             ->property('identifier', $token->accessToken->identifier)
                                                             ->log();
+
+                                                        Notification::make()
+                                                            ->title('API Key created')
+                                                            ->body($token->accessToken->identifier . $token->plainTextToken)
+                                                            ->persistent()
+                                                            ->success()
+                                                            ->send();
+
                                                         $action->success();
                                                     }),
                                             ]),


### PR DESCRIPTION
Fixes #768.

Yes, a notification is not the nicest thing but it is simple to do. Opening a modal is a headache.

Also fixes the hardcoded redirect url.