### PR TITLE
Remove unsaved changes alert

### DIFF
--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -23,7 +23,6 @@ use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Filament\Notifications\Notification;
-use Filament\Pages\Concerns\HasUnsavedDataChangesAlert;
 use Filament\Pages\Concerns\InteractsWithHeaderActions;
 use Filament\Pages\Page;
 use Filament\Support\Enums\MaxWidth;
@@ -39,7 +38,6 @@ use Illuminate\Support\HtmlString;
 class Settings extends Page implements HasForms
 {
     use EnvironmentWriterTrait;
-    use HasUnsavedDataChangesAlert;
     use InteractsWithForms;
     use InteractsWithHeaderActions;
 

--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -588,11 +588,6 @@ class Settings extends Page implements HasForms
         return 'data';
     }
 
-    protected function hasUnsavedDataChangesAlert(): bool
-    {
-        return true;
-    }
-
     public function save(): void
     {
         try {
@@ -605,8 +600,6 @@ class Settings extends Page implements HasForms
 
             Artisan::call('config:clear');
             Artisan::call('queue:restart');
-
-            $this->rememberData();
 
             $this->redirect($this->getUrl());
 

--- a/resources/views/filament/pages/settings.blade.php
+++ b/resources/views/filament/pages/settings.blade.php
@@ -1,15 +1,13 @@
 <x-filament-panels::page
-	@class([
-		'fi-page-settings'
-	])
+    @class([
+        'fi-page-settings'
+    ])
 >
     <x-filament-panels::form
-		id="form"
-		:wire:key="$this->getId() . '.forms.' . $this->getFormStatePath()"
-		wire:submit="save"
-	>
+        id="form"
+        :wire:key="$this->getId() . '.forms.' . $this->getFormStatePath()"
+        wire:submit="save"
+    >
         {{ $this->form }}
     </x-filament-panels::form>
-
-    <x-filament-panels::page.unsaved-data-changes-alert />
 </x-filament-panels::page>


### PR DESCRIPTION
Closes https://github.com/pelican-dev/panel/issues/773

It does not work as intended, as it ALWAYS says you have unsaved changes... So we can just remove it...