### PR TITLE
Move installer to correct namespace

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Filament\Pages\Installer\PanelInstaller;
+use App\Livewire\Installer\PanelInstaller;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Str;

--- a/app/Livewire/Installer/PanelInstaller.php
+++ b/app/Livewire/Installer/PanelInstaller.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace App\Filament\Pages\Installer;
+namespace App\Livewire\Installer;
 
 use App\Filament\Admin\Pages\Dashboard;
-use App\Filament\Pages\Installer\Steps\CacheStep;
-use App\Filament\Pages\Installer\Steps\DatabaseStep;
-use App\Filament\Pages\Installer\Steps\EnvironmentStep;
-use App\Filament\Pages\Installer\Steps\QueueStep;
-use App\Filament\Pages\Installer\Steps\RequirementsStep;
-use App\Filament\Pages\Installer\Steps\SessionStep;
+use App\Livewire\Installer\Steps\CacheStep;
+use App\Livewire\Installer\Steps\DatabaseStep;
+use App\Livewire\Installer\Steps\EnvironmentStep;
+use App\Livewire\Installer\Steps\QueueStep;
+use App\Livewire\Installer\Steps\RequirementsStep;
+use App\Livewire\Installer\Steps\SessionStep;
 use App\Models\User;
 use App\Services\Users\UserCreationService;
 use App\Traits\CheckMigrationsTrait;

--- a/app/Livewire/Installer/Steps/CacheStep.php
+++ b/app/Livewire/Installer/Steps/CacheStep.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Filament\Pages\Installer\Steps;
+namespace App\Livewire\Installer\Steps;
 
-use App\Filament\Pages\Installer\PanelInstaller;
+use App\Livewire\Installer\PanelInstaller;
 use Exception;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;

--- a/app/Livewire/Installer/Steps/DatabaseStep.php
+++ b/app/Livewire/Installer/Steps/DatabaseStep.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Filament\Pages\Installer\Steps;
+namespace App\Livewire\Installer\Steps;
 
-use App\Filament\Pages\Installer\PanelInstaller;
+use App\Livewire\Installer\PanelInstaller;
 use Exception;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;

--- a/app/Livewire/Installer/Steps/EnvironmentStep.php
+++ b/app/Livewire/Installer/Steps/EnvironmentStep.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Filament\Pages\Installer\Steps;
+namespace App\Livewire\Installer\Steps;
 
-use App\Filament\Pages\Installer\PanelInstaller;
+use App\Livewire\Installer\PanelInstaller;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Wizard\Step;

--- a/app/Livewire/Installer/Steps/QueueStep.php
+++ b/app/Livewire/Installer/Steps/QueueStep.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Filament\Pages\Installer\Steps;
+namespace App\Livewire\Installer\Steps;
 
-use App\Filament\Pages\Installer\PanelInstaller;
+use App\Livewire\Installer\PanelInstaller;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\ToggleButtons;

--- a/app/Livewire/Installer/Steps/RequirementsStep.php
+++ b/app/Livewire/Installer/Steps/RequirementsStep.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Pages\Installer\Steps;
+namespace App\Livewire\Installer\Steps;
 
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;

--- a/app/Livewire/Installer/Steps/SessionStep.php
+++ b/app/Livewire/Installer/Steps/SessionStep.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Pages\Installer\Steps;
+namespace App\Livewire\Installer\Steps;
 
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;

--- a/routes/base.php
+++ b/routes/base.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Filament\Pages\Installer\PanelInstaller;
+use App\Livewire\Installer\PanelInstaller;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Base;
 use App\Http\Middleware\RequireTwoFactorAuthentication;


### PR DESCRIPTION
This fixes the 500 error when clicking "Next".