### PR TITLE
Force installer width

### DIFF
--- a/app/Livewire/Installer/PanelInstaller.php
+++ b/app/Livewire/Installer/PanelInstaller.php
@@ -42,7 +42,7 @@ class PanelInstaller extends SimplePage implements HasForms
 
     public function getMaxWidth(): MaxWidth|string
     {
-        return config('panel.filament.display-width', 'screen-2xl');
+        return MaxWidth::SevenExtraLarge;
     }
 
     public static function isInstalled(): bool


### PR DESCRIPTION
Reverts [#770](https://github.com/pelican-dev/panel/pull/770/files#diff-b605ec9809fc3c090abfbb15e43f3792c7659b8d9b07f0a1f53b3540de093a3bR45) on PanelInstaller resulting in mobile layout even on desktop
![image](https://github.com/user-attachments/assets/878ca53d-5071-4d9d-bec5-712612993184)
