### PR TITLE
Add database notifications

### DIFF
--- a/app/Events/Server/Installed.php
+++ b/app/Events/Server/Installed.php
@@ -13,5 +13,5 @@ class Installed extends Event
     /**
      * Create a new event instance.
      */
-    public function __construct(public Server $server) {}
+    public function __construct(public Server $server, public bool $successful) {}
 }

--- a/app/Events/Server/Installed.php
+++ b/app/Events/Server/Installed.php
@@ -13,5 +13,5 @@ class Installed extends Event
     /**
      * Create a new event instance.
      */
-    public function __construct(public Server $server, public bool $successful) {}
+    public function __construct(public Server $server, public bool $successful, public bool $initialInstall) {}
 }

--- a/app/Events/Server/SubUserAdded.php
+++ b/app/Events/Server/SubUserAdded.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Events\Server;
+
+use App\Events\Event;
+use App\Models\Subuser;
+use Illuminate\Queue\SerializesModels;
+
+class SubUserAdded extends Event
+{
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Subuser $subuser) {}
+}

--- a/app/Events/Server/SubUserRemoved.php
+++ b/app/Events/Server/SubUserRemoved.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events\Server;
+
+use App\Events\Event;
+use App\Models\Server;
+use App\Models\User;
+use Illuminate\Queue\SerializesModels;
+
+class SubUserRemoved extends Event
+{
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Server $server, public User $user) {}
+}

--- a/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
@@ -35,13 +35,11 @@ class ServerInstallController extends Controller
     {
         $status = null;
 
-        // Make sure the type of failure is accurate
-        if (!$request->boolean('successful')) {
-            $status = ServerState::InstallFailed;
+        $successful = $request->boolean('successful');
 
-            if ($request->boolean('reinstall')) {
-                $status = ServerState::ReinstallFailed;
-            }
+        // Make sure the type of failure is accurate
+        if (!$successful) {
+            $status = $request->boolean('reinstall') ? ServerState::ReinstallFailed : ServerState::InstallFailed;
         }
 
         // Keep the server suspended if it's already suspended
@@ -59,11 +57,11 @@ class ServerInstallController extends Controller
         // This logic allows individually disabling install and reinstall notifications separately.
         $isInitialInstall = is_null($previouslyInstalledAt);
         if ($isInitialInstall && config()->get('panel.email.send_install_notification', true)) {
-            event(new ServerInstalled($server));
+            event(new ServerInstalled($server, $successful));
         }
 
         if (!$isInitialInstall && config()->get('panel.email.send_reinstall_notification', true)) {
-            event(new ServerInstalled($server));
+            event(new ServerInstalled($server, $successful));
         }
 
         return new JsonResponse([], Response::HTTP_NO_CONTENT);

--- a/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
@@ -53,16 +53,8 @@ class ServerInstallController extends Controller
         $server->installed_at = now();
         $server->save();
 
-        // If the server successfully installed, fire installed event.
-        // This logic allows individually disabling install and reinstall notifications separately.
         $isInitialInstall = is_null($previouslyInstalledAt);
-        if ($isInitialInstall && config()->get('panel.email.send_install_notification', true)) {
-            event(new ServerInstalled($server, $successful));
-        }
-
-        if (!$isInitialInstall && config()->get('panel.email.send_reinstall_notification', true)) {
-            event(new ServerInstalled($server, $successful));
-        }
+        event(new ServerInstalled($server, $successful, $isInitialInstall));
 
         return new JsonResponse([], Response::HTTP_NO_CONTENT);
     }

--- a/app/Listeners/Server/ServerInstalledListener.php
+++ b/app/Listeners/Server/ServerInstalledListener.php
@@ -16,7 +16,7 @@ class ServerInstalledListener
         Notification::make()
             ->status($event->successful ? 'success' : 'danger')
             ->title('Server ' . ($event->initialInstall ? 'Installation' : 'Reinstallation') . ' ' . ($event->successful ? 'completed' : 'failed'))
-            ->body($event->server->name)
+            ->body('Server Name: ' . $event->server->name)
             ->actions([
                 Action::make('view')
                     ->button()

--- a/app/Listeners/Server/ServerInstalledListener.php
+++ b/app/Listeners/Server/ServerInstalledListener.php
@@ -11,9 +11,11 @@ class ServerInstalledListener
 {
     public function handle(Installed $event): void
     {
+        $event->server->loadMissing('user');
+
         Notification::make()
             ->status($event->successful ? 'success' : 'danger')
-            ->title('Server Installation ' . ($event->successful ? 'completed' : 'failed'))
+            ->title('Server ' . ($event->initialInstall ? 'Installation' : 'Reinstallation') . ' ' . ($event->successful ? 'completed' : 'failed'))
             ->body($event->server->name)
             ->actions([
                 Action::make('view')

--- a/app/Listeners/Server/ServerInstalledListener.php
+++ b/app/Listeners/Server/ServerInstalledListener.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Listeners\Server;
+
+use App\Events\Server\Installed;
+use App\Filament\Server\Pages\Console;
+use Filament\Notifications\Actions\Action;
+use Filament\Notifications\Notification;
+
+class ServerInstalledListener
+{
+    public function handle(Installed $event): void
+    {
+        Notification::make()
+            ->status($event->successful ? 'success' : 'danger')
+            ->title('Server Installation ' . ($event->successful ? 'completed' : 'failed'))
+            ->body($event->server->name)
+            ->actions([
+                Action::make('view')
+                    ->button()
+                    ->label('Open Server')
+                    ->markAsRead()
+                    ->url(fn () => Console::getUrl(panel: 'server', tenant: $event->server)),
+            ])
+            ->sendToDatabase($event->server->user);
+    }
+}

--- a/app/Listeners/Server/SubUserAddedListener.php
+++ b/app/Listeners/Server/SubUserAddedListener.php
@@ -11,6 +11,9 @@ class SubUserAddedListener
 {
     public function handle(SubUserAdded $event): void
     {
+        $event->subuser->loadMissing('server');
+        $event->subuser->loadMissing('user');
+
         Notification::make()
             ->title('Added to Server')
             ->body('You have been added to ' . $event->subuser->server->name . '.')

--- a/app/Listeners/Server/SubUserAddedListener.php
+++ b/app/Listeners/Server/SubUserAddedListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Listeners\Server;
+
+use App\Events\Server\SubUserAdded;
+use App\Filament\Server\Pages\Console;
+use Filament\Notifications\Actions\Action;
+use Filament\Notifications\Notification;
+
+class SubUserAddedListener
+{
+    public function handle(SubUserAdded $event): void
+    {
+        Notification::make()
+            ->title('Added to Server')
+            ->body('You have been added to ' . $event->subuser->server->name . '.')
+            ->actions([
+                Action::make('view')
+                    ->button()
+                    ->label('Open Server')
+                    ->markAsRead()
+                    ->url(fn () => Console::getUrl(panel: 'server', tenant: $event->subuser->server)),
+            ])
+            ->sendToDatabase($event->subuser->user);
+    }
+}

--- a/app/Listeners/Server/SubUserAddedListener.php
+++ b/app/Listeners/Server/SubUserAddedListener.php
@@ -16,7 +16,7 @@ class SubUserAddedListener
 
         Notification::make()
             ->title('Added to Server')
-            ->body('You have been added to ' . $event->subuser->server->name . '.')
+            ->body('You have been added as a subuser to ' . $event->subuser->server->name . '.')
             ->actions([
                 Action::make('view')
                     ->button()

--- a/app/Listeners/Server/SubUserRemovedListener.php
+++ b/app/Listeners/Server/SubUserRemovedListener.php
@@ -3,8 +3,6 @@
 namespace App\Listeners\Server;
 
 use App\Events\Server\SubUserRemoved;
-use App\Filament\Server\Pages\Console;
-use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification;
 
 class SubUserRemovedListener
@@ -14,13 +12,6 @@ class SubUserRemovedListener
         Notification::make()
             ->title('Removed from Server')
             ->body('You have been removed as a subuser from ' . $event->server->name . '.')
-            ->actions([
-                Action::make('view')
-                    ->button()
-                    ->label('Open Server')
-                    ->markAsRead()
-                    ->url(fn () => Console::getUrl(panel: 'server', tenant: $event->server)),
-            ])
             ->sendToDatabase($event->user);
     }
 }

--- a/app/Listeners/Server/SubUserRemovedListener.php
+++ b/app/Listeners/Server/SubUserRemovedListener.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Listeners\Server;
+
+use App\Events\Server\SubUserRemoved;
+use App\Filament\Server\Pages\Console;
+use Filament\Notifications\Actions\Action;
+use Filament\Notifications\Notification;
+
+class SubUserRemovedListener
+{
+    public function handle(SubUserRemoved $event): void
+    {
+        Notification::make()
+            ->title('Removed from Server')
+            ->body('You have been removed as a subuser from ' . $event->server->name . '.')
+            ->actions([
+                Action::make('view')
+                    ->button()
+                    ->label('Open Server')
+                    ->markAsRead()
+                    ->url(fn () => Console::getUrl(panel: 'server', tenant: $event->server)),
+            ])
+            ->sendToDatabase($event->user);
+    }
+}

--- a/app/Notifications/AddedToServer.php
+++ b/app/Notifications/AddedToServer.php
@@ -2,7 +2,12 @@
 
 namespace App\Notifications;
 
+use App\Events\Server\SubUserAdded;
+use App\Models\Server;
+use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Notifications\Dispatcher;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -11,14 +16,22 @@ class AddedToServer extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public object $server;
+    public Server $server;
+
+    public User $user;
 
     /**
-     * Create a new notification instance.
+     * Handle a direct call to this notification from the subuser added event. This is configured
+     * in the event service provider.
      */
-    public function __construct(array $server)
+    public function handle(SubUserAdded $event): void
     {
-        $this->server = (object) $server;
+        $this->server = $event->subuser->server;
+        $this->user = $event->subuser->user;
+
+        // Since we are calling this notification directly from an event listener we need to fire off the dispatcher
+        // to send the email now. Don't use send() or you'll end up firing off two different events.
+        Container::getInstance()->make(Dispatcher::class)->sendNow($this->user, $this);
     }
 
     /**
@@ -35,7 +48,7 @@ class AddedToServer extends Notification implements ShouldQueue
     public function toMail(): MailMessage
     {
         return (new MailMessage())
-            ->greeting('Hello ' . $this->server->user . '!')
+            ->greeting('Hello ' . $this->user->username . '!')
             ->line('You have been added as a subuser for the following server, allowing you certain control over the server.')
             ->line('Server Name: ' . $this->server->name)
             ->action('Visit Server', url('/server/' . $this->server->uuid_short));

--- a/app/Notifications/ServerInstalled.php
+++ b/app/Notifications/ServerInstalled.php
@@ -4,7 +4,6 @@ namespace App\Notifications;
 
 use App\Models\User;
 use Illuminate\Bus\Queueable;
-use App\Events\Event;
 use App\Models\Server;
 use Illuminate\Container\Container;
 use App\Events\Server\Installed;

--- a/app/Notifications/ServerInstalled.php
+++ b/app/Notifications/ServerInstalled.php
@@ -26,14 +26,24 @@ class ServerInstalled extends Notification implements ShouldQueue
      */
     public function handle(Installed $event): void
     {
-        $event->server->loadMissing('user');
+        if ($event->initialInstall && !config()->get('panel.email.send_install_notification', true)) {
+            return;
+        }
 
-        $this->server = $event->server;
-        $this->user = $event->server->user;
+        if (!$event->initialInstall && !config()->get('panel.email.send_reinstall_notification', true)) {
+            return;
+        }
 
-        // Since we are calling this notification directly from an event listener we need to fire off the dispatcher
-        // to send the email now. Don't use send() or you'll end up firing off two different events.
-        Container::getInstance()->make(Dispatcher::class)->sendNow($this->user, $this);
+        if ($event->successful) {
+            $event->server->loadMissing('user');
+
+            $this->server = $event->server;
+            $this->user = $event->server->user;
+
+            // Since we are calling this notification directly from an event listener we need to fire off the dispatcher
+            // to send the email now. Don't use send() or you'll end up firing off two different events.
+            Container::getInstance()->make(Dispatcher::class)->sendNow($this->user, $this);
+        }
     }
 
     /**

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -55,6 +55,7 @@ class AdminPanelProvider extends PanelProvider
             ->spa()
             ->discoverResources(in: app_path('Filament/Admin/Resources'), for: 'App\\Filament\\Admin\\Resources')
             ->discoverPages(in: app_path('Filament/Admin/Pages'), for: 'App\\Filament\\Admin\\Pages')
+            ->databaseNotifications()
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -46,6 +46,7 @@ class AppPanelProvider extends PanelProvider
                     ->visible(fn (): bool => auth()->user()->canAccessPanel(Filament::getPanel('admin'))),
             ])
             ->discoverResources(in: app_path('Filament/App/Resources'), for: 'App\\Filament\\App\\Resources')
+            ->databaseNotifications()
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/app/Providers/Filament/ServerPanelProvider.php
+++ b/app/Providers/Filament/ServerPanelProvider.php
@@ -65,6 +65,7 @@ class ServerPanelProvider extends PanelProvider
             ->discoverResources(in: app_path('Filament/Server/Resources'), for: 'App\\Filament\\Server\\Resources')
             ->discoverPages(in: app_path('Filament/Server/Pages'), for: 'App\\Filament\\Server\\Pages')
             ->discoverWidgets(in: app_path('Filament/Server/Widgets'), for: 'App\\Filament\\Server\\Widgets')
+            ->databaseNotifications()
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/app/Services/Subusers/SubuserCreationService.php
+++ b/app/Services/Subusers/SubuserCreationService.php
@@ -2,8 +2,8 @@
 
 namespace App\Services\Subusers;
 
+use App\Events\Server\SubUserAdded;
 use App\Models\User;
-use App\Notifications\AddedToServer;
 use Illuminate\Support\Str;
 use App\Models\Server;
 use App\Models\Subuser;
@@ -63,11 +63,7 @@ class SubuserCreationService
                 'permissions' => array_unique($permissions),
             ]);
 
-            $subuser->user->notify(new AddedToServer([
-                'user' => $subuser->user->name_first,
-                'name' => $subuser->server->name,
-                'uuid_short' => $subuser->server->uuid_short,
-            ]));
+            event(new SubUserAdded($subuser));
 
             return $subuser;
         });

--- a/app/Services/Subusers/SubuserDeletionService.php
+++ b/app/Services/Subusers/SubuserDeletionService.php
@@ -2,11 +2,11 @@
 
 namespace App\Services\Subusers;
 
+use App\Events\Server\SubUserRemoved;
 use App\Exceptions\Http\Connection\DaemonConnectionException;
 use App\Facades\Activity;
 use App\Models\Server;
 use App\Models\Subuser;
-use App\Notifications\RemovedFromServer;
 use App\Repositories\Daemon\DaemonServerRepository;
 
 class SubuserDeletionService
@@ -25,10 +25,7 @@ class SubuserDeletionService
         $log->transaction(function ($instance) use ($server, $subuser) {
             $subuser->delete();
 
-            $subuser->user->notify(new RemovedFromServer([
-                'user' => $subuser->user->name_first,
-                'name' => $subuser->server->name,
-            ]));
+            event(new SubUserRemoved($subuser->server, $subuser->user));
 
             try {
                 $this->serverRepository->setServer($server)->revokeUserJTI($subuser->user_id);

--- a/tests/Feature/Webhooks/ProcessWebhooksTest.php
+++ b/tests/Feature/Webhooks/ProcessWebhooksTest.php
@@ -185,7 +185,7 @@ class ProcessWebhooksTest extends TestCase
 
         $server = $this->createServer();
 
-        event(new Installed($server));
+        event(new Installed($server, true));
 
         $this->assertDatabaseCount(Webhook::class, 1);
         $this->assertDatabaseHas(Webhook::class, [

--- a/tests/Feature/Webhooks/ProcessWebhooksTest.php
+++ b/tests/Feature/Webhooks/ProcessWebhooksTest.php
@@ -185,7 +185,7 @@ class ProcessWebhooksTest extends TestCase
 
         $server = $this->createServer();
 
-        event(new Installed($server, true));
+        event(new Installed($server, true, true));
 
         $this->assertDatabaseCount(Webhook::class, 1);
         $this->assertDatabaseHas(Webhook::class, [


### PR DESCRIPTION
Database notifications are sent for the following events:

- Server is (re-) installed
- User is added as subuser
- User is removed as subuser

_(Note: the mail sending for subusers is now also handled via events)_

![image](https://github.com/user-attachments/assets/9a028f59-3612-4c7b-b56c-d75724a5b054)