### PR TITLE
Fix wrong language formatting in charts

### DIFF
--- a/app/Filament/Admin/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Admin/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -26,8 +26,8 @@ class NodeCpuChart extends ChartWidget
         $cpu = collect(cache()->get("nodes.$node->id.cpu_percent"))
             ->slice(-10)
             ->map(fn ($value, $key) => [
-                'cpu' => Number::format($value * $threads, maxPrecision: 2, locale: auth()->user()->language),
-                'timestamp' => Carbon::createFromTimestamp($key, (auth()->user()->timezone ?? 'UTC'))->format('H:i:s'),
+                'cpu' => Number::format($value * $threads, maxPrecision: 2),
+                'timestamp' => Carbon::createFromTimestamp($key, auth()->user()->timezone ?? 'UTC')->format('H:i:s'),
             ])
             ->all();
 
@@ -43,6 +43,7 @@ class NodeCpuChart extends ChartWidget
                 ],
             ],
             'labels' => array_column($cpu, 'timestamp'),
+            'locale' => auth()->user()->language ?? 'en',
         ];
     }
 

--- a/app/Filament/Admin/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Admin/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -24,8 +24,8 @@ class NodeMemoryChart extends ChartWidget
 
         $memUsed = collect(cache()->get("nodes.$node->id.memory_used"))->slice(-10)
             ->map(fn ($value, $key) => [
-                'memory' => Number::format(config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1000 / 1000 / 1000, maxPrecision: 2, locale: auth()->user()->language),
-                'timestamp' => Carbon::createFromTimestamp($key, (auth()->user()->timezone ?? 'UTC'))->format('H:i:s'),
+                'memory' => Number::format(config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1000 / 1000 / 1000, maxPrecision: 2),
+                'timestamp' => Carbon::createFromTimestamp($key, auth()->user()->timezone ?? 'UTC')->format('H:i:s'),
             ])
             ->all();
 
@@ -41,6 +41,7 @@ class NodeMemoryChart extends ChartWidget
                 ],
             ],
             'labels' => array_column($memUsed, 'timestamp'),
+            'locale' => auth()->user()->language ?? 'en',
         ];
     }
 

--- a/app/Filament/Server/Widgets/ServerCpuChart.php
+++ b/app/Filament/Server/Widgets/ServerCpuChart.php
@@ -21,8 +21,8 @@ class ServerCpuChart extends ChartWidget
         $cpu = collect(cache()->get("servers.{$this->server->id}.cpu_absolute"))
             ->slice(-10)
             ->map(fn ($value, $key) => [
-                'cpu' => Number::format($value, maxPrecision: 2, locale: auth()->user()->language),
-                'timestamp' => Carbon::createFromTimestamp($key, (auth()->user()->timezone ?? 'UTC'))->format('H:i:s'),
+                'cpu' => Number::format($value, maxPrecision: 2),
+                'timestamp' => Carbon::createFromTimestamp($key, auth()->user()->timezone ?? 'UTC')->format('H:i:s'),
             ])
             ->all();
 
@@ -38,6 +38,7 @@ class ServerCpuChart extends ChartWidget
                 ],
             ],
             'labels' => array_column($cpu, 'timestamp'),
+            'locale' => auth()->user()->language ?? 'en',
         ];
     }
 

--- a/app/Filament/Server/Widgets/ServerMemoryChart.php
+++ b/app/Filament/Server/Widgets/ServerMemoryChart.php
@@ -20,8 +20,8 @@ class ServerMemoryChart extends ChartWidget
     {
         $memUsed = collect(cache()->get("servers.{$this->server->id}.memory_bytes"))->slice(-10)
             ->map(fn ($value, $key) => [
-                'memory' => Number::format(config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1000 / 1000 / 1000, maxPrecision: 2, locale: auth()->user()->language),
-                'timestamp' => Carbon::createFromTimestamp($key, (auth()->user()->timezone ?? 'UTC'))->format('H:i:s'),
+                'memory' => Number::format(config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1000 / 1000 / 1000, maxPrecision: 2),
+                'timestamp' => Carbon::createFromTimestamp($key, auth()->user()->timezone ?? 'UTC')->format('H:i:s'),
             ])
             ->all();
 
@@ -37,6 +37,7 @@ class ServerMemoryChart extends ChartWidget
                 ],
             ],
             'labels' => array_column($memUsed, 'timestamp'),
+            'locale' => auth()->user()->language ?? 'en',
         ];
     }
 


### PR DESCRIPTION
Set the locale in the chart itself rather than formatting the values in the user locale.

(ref ["Stats not working after upgrade" on Discord](https://discord.com/channels/1218730176297439332/1316778213803950162))