### PR TITLE
fix: create database fails with 500

### DIFF
--- a/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
@@ -723,8 +723,10 @@ class EditServer extends EditRecord
                                                 ->label('Database Host')
                                                 ->required()
                                                 ->placeholder('Select Database Host')
-                                                ->relationship('node.databaseHosts', 'name',
-                                                    fn (Builder $query, Server $server) => $query->whereRelation('nodes', 'nodes.id', $server->node_id))
+                                                ->options(fn (Server $server) => DatabaseHost::query()
+                                                    ->whereHas('nodes', fn ($query) => $query->where('nodes.id', $server->node_id))
+                                                    ->pluck('name', 'id')
+                                                )
                                                 ->default(fn () => (DatabaseHost::query()->first())?->id)
                                                 ->selectablePlaceholder(false),
                                             TextInput::make('database')


### PR DESCRIPTION
The `relationship()` method assumes that the form field is working with belongsToMany or hasManyThrough relationships. In this case, it seems to be interacting with a pivot table (database_host_node), which is causing it to attempt inserting a new record into the pivot table whenever the form submits.

Changelogs:
- Changed `relationship` to `options`.

Closes #805