### PR TITLE
Make backup name not required in new area

### DIFF
--- a/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
@@ -44,8 +44,7 @@ class ListBackups extends ListRecords
             ->schema([
                 TextInput::make('name')
                     ->label('Name')
-                    ->columnSpanFull()
-                    ->required(),
+                    ->columnSpanFull(),
                 TextArea::make('ignored')
                     ->columnSpanFull()
                     ->label('Ignored Files & Directories'),


### PR DESCRIPTION
It wasn't in the old one https://github.com/pelican-dev/panel/blob/133c1a511fcc3ebd2c3d69459776ddd0dc737956/app/Services/Backups/InitiateBackupService.php#L116