### PR TITLE
Strip http/ https from steam oauth `allowed_host`

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -130,7 +130,7 @@ return [
                 'client_id' => null,
                 'client_secret' => env('OAUTH_STEAM_CLIENT_SECRET'),
                 'allowed_hosts' => [
-                    env('APP_URL'),
+                    str_replace(env('APP_URL'), ['http://', 'https://'], ''),
                 ],
             ],
             'provider' => \SocialiteProviders\Steam\Provider::class,

--- a/config/auth.php
+++ b/config/auth.php
@@ -130,7 +130,7 @@ return [
                 'client_id' => null,
                 'client_secret' => env('OAUTH_STEAM_CLIENT_SECRET'),
                 'allowed_hosts' => [
-                    str_replace(env('APP_URL'), ['http://', 'https://'], ''),
+                    str_replace(['http://', 'https://'], '', env('APP_URL')),
                 ],
             ],
             'provider' => \SocialiteProviders\Steam\Provider::class,


### PR DESCRIPTION
Fixes `Invalid return_to host` errors.