### PR TITLE
Speed up Docker build and fix entrypoint permissions

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -33,17 +33,17 @@ ln -s /pelican-data/database/database.sqlite /var/www/html/database/
 
 if ! grep -q "APP_KEY=" .env || grep -q "APP_KEY=$" .env; then
   echo "Generating APP_KEY..."
-  php artisan key:generate --force
+  su -s /bin/ash -c "php artisan key:generate --force" www-data
 else
   echo "APP_KEY is already set."
 fi
 
 ## make sure the db is set up
 echo -e "Migrating Database"
-php artisan migrate --force
+su -s /bin/ash -c "php artisan migrate --force" www-data
 
 echo -e "Optimizing Filament"
-php artisan filament:optimize
+su -s /bin/ash -c "php artisan filament:optimize" www-data
 
 ## start cronjobs for the queue
 echo -e "Starting cron jobs."

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ FROM node:20-alpine AS yarn
 
 WORKDIR /build
 
-COPY . ./
+COPY package.json yarn.lock ./
 
 RUN yarn config set network-timeout 300000 \
-    && yarn install --frozen-lockfile \
-    && yarn run build:production
+    && yarn install --frozen-lockfile
+
+COPY . ./
+
+RUN yarn run build:production
 
 FROM php:8.3-fpm-alpine
 # FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine
@@ -49,7 +52,7 @@ RUN cp .github/docker/supervisord.conf /etc/supervisord.conf && \
     mkdir /var/log/supervisord/
 
 HEALTHCHECK --interval=5m --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost/up || exit 1
+    CMD curl -f http://localhost/up || exit 1
 
 EXPOSE 80 443
 

--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,8 @@ x-common:
 services:
   panel:
     image: ghcr.io/pelican-dev/panel:latest
+    build:
+      dockerfile: ./Dockerfile
     restart: always
     networks:
       - default


### PR DESCRIPTION
The Docker entrypoint script runs artisan commands as root, which creates directories under `storage/framework/cache/data` that are owned by root. This causes errors when running the panel, as it's unable to write to parts of the cache. By running the commands as www-data instead, the permissions are kept unaffected.

I added the Dockerfile to the compose file, so that the image can easily be built from source if desired.

As the `yarn install` command can take a long time, I changed the Dockerfile to copy just the necessary package/yarn files for the installation first. Once that is completed, it copies the rest and builds the app. This sped up cached builds on my computer by about 80 seconds.