### PR TITLE
Make DynamicDatabaseConnection static

### DIFF
--- a/app/Extensions/DynamicDatabaseConnection.php
+++ b/app/Extensions/DynamicDatabaseConnection.php
@@ -15,7 +15,7 @@ class DynamicDatabaseConnection
     /**
      * Adds a dynamic database connection entry to the runtime config.
      */
-    public function set(string $connection, DatabaseHost|int $host, string $database = 'mysql'): void
+    public static function set(string $connection, DatabaseHost|int $host, string $database = 'mysql'): void
     {
         if (!$host instanceof DatabaseHost) {
             $host = DatabaseHost::query()->findOrFail($host);

--- a/app/Services/Databases/DatabaseManagementService.php
+++ b/app/Services/Databases/DatabaseManagementService.php
@@ -31,7 +31,6 @@ class DatabaseManagementService
 
     public function __construct(
         protected ConnectionInterface $connection,
-        protected DynamicDatabaseConnection $dynamic,
     ) {}
 
     /**
@@ -91,7 +90,7 @@ class DatabaseManagementService
         return $this->connection->transaction(function () use ($data) {
             $database = $this->createModel($data);
 
-            $this->dynamic->set('dynamic', $data['database_host_id']);
+            DynamicDatabaseConnection::set('dynamic', $data['database_host_id']);
 
             $database->createDatabase($database->database);
             $database->createUser(
@@ -114,7 +113,7 @@ class DatabaseManagementService
      */
     public function delete(Database $database): ?bool
     {
-        $this->dynamic->set('dynamic', $database->database_host_id);
+        DynamicDatabaseConnection::set('dynamic', $database->database_host_id);
 
         $database->dropDatabase($database->database);
         $database->dropUser($database->username, $database->remote);

--- a/app/Services/Databases/DatabasePasswordService.php
+++ b/app/Services/Databases/DatabasePasswordService.php
@@ -14,7 +14,6 @@ class DatabasePasswordService
      */
     public function __construct(
         private ConnectionInterface $connection,
-        private DynamicDatabaseConnection $dynamic,
     ) {}
 
     /**
@@ -29,7 +28,7 @@ class DatabasePasswordService
         $password = Utilities::randomStringWithSpecialCharacters(24);
 
         $this->connection->transaction(function () use ($database, $password) {
-            $this->dynamic->set('dynamic', $database->database_host_id);
+            DynamicDatabaseConnection::set('dynamic', $database->database_host_id);
 
             $database->update([
                 'password' => $password,

--- a/app/Services/Databases/Hosts/HostCreationService.php
+++ b/app/Services/Databases/Hosts/HostCreationService.php
@@ -15,7 +15,6 @@ class HostCreationService
     public function __construct(
         private ConnectionInterface $connection,
         private DatabaseManager $databaseManager,
-        private DynamicDatabaseConnection $dynamic,
     ) {}
 
     /**
@@ -38,7 +37,7 @@ class HostCreationService
             $host->nodes()->sync(array_get($data, 'node_ids', []));
 
             // Confirm access using the provided credentials before saving data.
-            $this->dynamic->set('dynamic', $host);
+            DynamicDatabaseConnection::set('dynamic', $host);
             $this->databaseManager->connection('dynamic')->getPdo();
 
             return $host;

--- a/app/Services/Databases/Hosts/HostUpdateService.php
+++ b/app/Services/Databases/Hosts/HostUpdateService.php
@@ -15,7 +15,6 @@ class HostUpdateService
     public function __construct(
         private ConnectionInterface $connection,
         private DatabaseManager $databaseManager,
-        private DynamicDatabaseConnection $dynamic,
     ) {}
 
     /**
@@ -36,7 +35,7 @@ class HostUpdateService
         return $this->connection->transaction(function () use ($data, $host) {
             $host->update($data);
 
-            $this->dynamic->set('dynamic', $host);
+            DynamicDatabaseConnection::set('dynamic', $host);
             $this->databaseManager->connection('dynamic')->getPdo();
 
             return $host;


### PR DESCRIPTION
I thought it was odd that this class, which has no internal state or anything, wasn't a static method and required instantiating the class first.
Does this seem reasonable to change, or is there some plan for it?