### PR TITLE
Fix deleting database host when it has assigned nodes

### DIFF
--- a/database/migrations/2025_01_09_143607_database_host_node_foreign_delete_cascade.php
+++ b/database/migrations/2025_01_09_143607_database_host_node_foreign_delete_cascade.php
@@ -20,7 +20,5 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down(): void
-    {
-    }
+    public function down(): void {}
 };

--- a/database/migrations/2025_01_09_143607_database_host_node_foreign_delete_cascade.php
+++ b/database/migrations/2025_01_09_143607_database_host_node_foreign_delete_cascade.php
@@ -22,9 +22,5 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('database_host_node', function (Blueprint $table) {
-            $table->dropForeign(['database_host_id']);
-            $table->foreign('database_host_id')->references('id')->on('database_hosts')->noActionOnDelete();
-        });
     }
 };

--- a/database/migrations/2025_01_09_143607_database_host_node_foreign_delete_cascade.php
+++ b/database/migrations/2025_01_09_143607_database_host_node_foreign_delete_cascade.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('database_host_node', function (Blueprint $table) {
+            $table->dropForeign(['database_host_id']);
+            $table->foreign('database_host_id')->references('id')->on('database_hosts')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('database_host_node', function (Blueprint $table) {
+            $table->dropForeign(['database_host_id']);
+            $table->foreign('database_host_id')->references('id')->on('database_hosts')->noActionOnDelete();
+        });
+    }
+};


### PR DESCRIPTION
Deleting a database host with assigned nodes currently throws a foreign key constraint error. This migration will cascade delete the node assignments as well, but maybe it'd be preferable to just show an error and ask the user to remove the node assignments?