### PR TITLE
`files` tooltip for activity logs

### DIFF
--- a/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
+++ b/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
@@ -26,7 +26,8 @@ class ListActivities extends ListRecords
                         $properties = $activityLog->wrapProperties();
 
                         return trans_choice('activity.'.str($state)->replace(':', '.'), array_get($properties, 'count', 1), $properties);
-                    }),
+                    })
+                    ->tooltip(fn (ActivityLog $activityLog) => implode(',', array_get($activityLog->properties, 'files', []))),
                 TextColumn::make('user')
                     ->state(fn (ActivityLog $activityLog) => $activityLog->actor instanceof User ? $activityLog->actor->username : 'System')
                     ->tooltip(fn (ActivityLog $activityLog) => auth()->user()->can('seeIps activityLog') ? $activityLog->ip : '')

--- a/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
+++ b/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
@@ -27,7 +27,11 @@ class ListActivities extends ListRecords
 
                         return trans_choice('activity.'.str($state)->replace(':', '.'), array_get($properties, 'count', 1), $properties);
                     })
-                    ->tooltip(fn (ActivityLog $activityLog) => implode(',', array_get($activityLog->properties, 'files', []))),
+                    ->tooltip(function (ActivityLog $activityLog) {
+                        $files = array_get($activityLog->properties, 'files', []);
+
+                        return is_array($files) ? implode(',', $files) : null;
+                    }),
                 TextColumn::make('user')
                     ->state(fn (ActivityLog $activityLog) => $activityLog->actor instanceof User ? $activityLog->actor->username : 'System')
                     ->tooltip(fn (ActivityLog $activityLog) => auth()->user()->can('seeIps activityLog') ? $activityLog->ip : '')


### PR DESCRIPTION
Adds a simple tooltip to activity logs that have a `files` property, e.g. when deleting multiple files.

![grafik](https://github.com/user-attachments/assets/c558b997-f16d-4312-b1ed-0fcb7b85f019)