### PR TITLE
[Fix] Websocket Tokens Refresh issue

### DIFF
--- a/app/Filament/Server/Widgets/ServerConsole.php
+++ b/app/Filament/Server/Widgets/ServerConsole.php
@@ -103,6 +103,12 @@ class ServerConsole extends Widget
         }
     }
 
+    #[On('token-request')]
+    public function tokenRequest(): void
+    {
+        $this->dispatch('sendAuthRequest', token: $this->getToken());
+    }
+
     #[On('store-stats')]
     public function storeStats(string $data): void
     {

--- a/resources/views/filament/components/server-console.blade.php
+++ b/resources/views/filament/components/server-console.blade.php
@@ -149,21 +149,13 @@
                     break;
                 case 'token expiring':
                 case 'token expired':
-                    token = '{{ $this->getToken() }}';
-
-                    socket.send(JSON.stringify({
-                        'event': 'auth',
-                        'args': [token]
-                    }));
+                    $wire.dispatchSelf('token-request');
                     break;
             }
         };
 
         socket.onopen = (event) => {
-            socket.send(JSON.stringify({
-                'event': 'auth',
-                'args': [token]
-            }));
+            $wire.dispatchSelf('token-request');
         };
 
         Livewire.on('setServerState', ({ state, uuid }) => {
@@ -175,6 +167,13 @@
             socket.send(JSON.stringify({
                 'event': 'set state',
                 'args': [state]
+            }));
+        });
+
+        $wire.on('sendAuthRequest', ({ token }) => {
+            socket.send(JSON.stringify({
+                'event': 'auth',
+                'args': [token]
             }));
         });
 


### PR DESCRIPTION
Basic fix of current issue of tokens not refreshing. It looks like once the blade is cached it turns static and doesn't properly update variables until a page reload occurs.

Workaround is to have livewire dispatch any token requests and handle them on a public tokenRequest function that will inturn send another dispatch with the token from $this->getToken() and handle the final websocket message for auth with the token.

Any further requests or issues, even suggestions are welcome.