### PR TITLE
Fix event listeners for notifications

### DIFF
--- a/app/Listeners/Server/ServerInstalledListener.php
+++ b/app/Listeners/Server/ServerInstalledListener.php
@@ -4,6 +4,7 @@ namespace App\Listeners\Server;
 
 use App\Events\Server\Installed;
 use App\Filament\Server\Pages\Console;
+use App\Notifications\ServerInstalled;
 use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification;
 
@@ -25,5 +26,10 @@ class ServerInstalledListener
                     ->url(fn () => Console::getUrl(panel: 'server', tenant: $event->server)),
             ])
             ->sendToDatabase($event->server->user);
+
+        if (($event->initialInstall && config()->get('panel.email.send_install_notification', true)) ||
+            (!$event->initialInstall && config()->get('panel.email.send_reinstall_notification', true))) {
+            $event->server->user->notify(new ServerInstalled($event->server));
+        }
     }
 }

--- a/app/Listeners/Server/SubUserAddedListener.php
+++ b/app/Listeners/Server/SubUserAddedListener.php
@@ -4,6 +4,7 @@ namespace App\Listeners\Server;
 
 use App\Events\Server\SubUserAdded;
 use App\Filament\Server\Pages\Console;
+use App\Notifications\AddedToServer;
 use Filament\Notifications\Actions\Action;
 use Filament\Notifications\Notification;
 
@@ -25,5 +26,7 @@ class SubUserAddedListener
                     ->url(fn () => Console::getUrl(panel: 'server', tenant: $event->subuser->server)),
             ])
             ->sendToDatabase($event->subuser->user);
+
+        $event->subuser->user->notify(new AddedToServer($event->subuser->server));
     }
 }

--- a/app/Listeners/Server/SubUserRemovedListener.php
+++ b/app/Listeners/Server/SubUserRemovedListener.php
@@ -3,6 +3,7 @@
 namespace App\Listeners\Server;
 
 use App\Events\Server\SubUserRemoved;
+use App\Notifications\RemovedFromServer;
 use Filament\Notifications\Notification;
 
 class SubUserRemovedListener
@@ -13,5 +14,7 @@ class SubUserRemovedListener
             ->title('Removed from Server')
             ->body('You have been removed as a subuser from ' . $event->server->name . '.')
             ->sendToDatabase($event->user);
+
+        $event->user->notify(new RemovedFromServer($event->server));
     }
 }

--- a/app/Notifications/AccountCreated.php
+++ b/app/Notifications/AccountCreated.php
@@ -12,32 +12,23 @@ class AccountCreated extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    /**
-     * Create a new notification instance.
-     */
-    public function __construct(public User $user, public ?string $token = null) {}
+    public function __construct(public ?string $token = null) {}
 
-    /**
-     * Get the notification's delivery channels.
-     */
     public function via(): array
     {
         return ['mail'];
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
-    public function toMail(): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         $message = (new MailMessage())
-            ->greeting('Hello ' . $this->user->name . '!')
+            ->greeting('Hello ' . $notifiable->name . '!')
             ->line('You are receiving this email because an account has been created for you on ' . config('app.name') . '.')
-            ->line('Username: ' . $this->user->username)
-            ->line('Email: ' . $this->user->email);
+            ->line('Username: ' . $notifiable->username)
+            ->line('Email: ' . $notifiable->email);
 
         if (!is_null($this->token)) {
-            return $message->action('Setup Your Account', url('/auth/password/reset/' . $this->token . '?email=' . urlencode($this->user->email)));
+            return $message->action('Setup Your Account', url('/auth/password/reset/' . $this->token . '?email=' . urlencode($notifiable->email)));
         }
 
         return $message;

--- a/app/Notifications/AddedToServer.php
+++ b/app/Notifications/AddedToServer.php
@@ -2,12 +2,9 @@
 
 namespace App\Notifications;
 
-use App\Events\Server\SubUserAdded;
 use App\Models\Server;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Notifications\Dispatcher;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -16,39 +13,17 @@ class AddedToServer extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public Server $server;
+    public function __construct(public Server $server) {}
 
-    public User $user;
-
-    /**
-     * Handle a direct call to this notification from the subuser added event. This is configured
-     * in the event service provider.
-     */
-    public function handle(SubUserAdded $event): void
-    {
-        $this->server = $event->subuser->server;
-        $this->user = $event->subuser->user;
-
-        // Since we are calling this notification directly from an event listener we need to fire off the dispatcher
-        // to send the email now. Don't use send() or you'll end up firing off two different events.
-        Container::getInstance()->make(Dispatcher::class)->sendNow($this->user, $this);
-    }
-
-    /**
-     * Get the notification's delivery channels.
-     */
     public function via(): array
     {
         return ['mail'];
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
-    public function toMail(): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         return (new MailMessage())
-            ->greeting('Hello ' . $this->user->username . '!')
+            ->greeting('Hello ' . $notifiable->username . '!')
             ->line('You have been added as a subuser for the following server, allowing you certain control over the server.')
             ->line('Server Name: ' . $this->server->name)
             ->action('Visit Server', url('/server/' . $this->server->uuid_short));

--- a/app/Notifications/RemovedFromServer.php
+++ b/app/Notifications/RemovedFromServer.php
@@ -2,7 +2,6 @@
 
 namespace App\Notifications;
 
-use App\Filament\App\Resources\ServerResource\Pages\ListServers;
 use App\Models\Server;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
@@ -28,6 +27,6 @@ class RemovedFromServer extends Notification implements ShouldQueue
             ->greeting('Hello ' . $notifiable->username . '.')
             ->line('You have been removed as a subuser for the following server.')
             ->line('Server Name: ' . $this->server->name)
-            ->action('Visit Panel', ListServers::getUrl());
+            ->action('Visit Panel', config('app.url'));
     }
 }

--- a/app/Notifications/RemovedFromServer.php
+++ b/app/Notifications/RemovedFromServer.php
@@ -2,13 +2,10 @@
 
 namespace App\Notifications;
 
-use App\Events\Server\SubUserRemoved;
 use App\Filament\App\Resources\ServerResource\Pages\ListServers;
 use App\Models\Server;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Notifications\Dispatcher;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -17,40 +14,18 @@ class RemovedFromServer extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public Server $server;
+    public function __construct(public Server $server) {}
 
-    public User $user;
-
-    /**
-     * Handle a direct call to this notification from the subuser removed event. This is configured
-     * in the event service provider.
-     */
-    public function handle(SubUserRemoved $event): void
-    {
-        $this->server = $event->server;
-        $this->user = $event->user;
-
-        // Since we are calling this notification directly from an event listener we need to fire off the dispatcher
-        // to send the email now. Don't use send() or you'll end up firing off two different events.
-        Container::getInstance()->make(Dispatcher::class)->sendNow($this->user, $this);
-    }
-
-    /**
-     * Get the notification's delivery channels.
-     */
     public function via(): array
     {
         return ['mail'];
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
-    public function toMail(): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         return (new MailMessage())
             ->error()
-            ->greeting('Hello ' . $this->user->username . '.')
+            ->greeting('Hello ' . $notifiable->username . '.')
             ->line('You have been removed as a subuser for the following server.')
             ->line('Server Name: ' . $this->server->name)
             ->action('Visit Panel', ListServers::getUrl());

--- a/app/Notifications/SendPasswordReset.php
+++ b/app/Notifications/SendPasswordReset.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -11,23 +12,14 @@ class SendPasswordReset extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    /**
-     * Create a new notification instance.
-     */
     public function __construct(public string $token) {}
 
-    /**
-     * Get the notification's delivery channels.
-     */
     public function via(): array
     {
         return ['mail'];
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
-    public function toMail(mixed $notifiable): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         return (new MailMessage())
             ->subject('Reset Password')

--- a/app/Notifications/ServerInstalled.php
+++ b/app/Notifications/ServerInstalled.php
@@ -5,63 +5,26 @@ namespace App\Notifications;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use App\Models\Server;
-use Illuminate\Container\Container;
-use App\Events\Server\Installed;
 use App\Filament\App\Resources\ServerResource\Pages\ListServers;
 use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Contracts\Notifications\Dispatcher;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class ServerInstalled extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public Server $server;
+    public function __construct(public Server $server) {}
 
-    public User $user;
-
-    /**
-     * Handle a direct call to this notification from the server installed event. This is configured
-     * in the event service provider.
-     */
-    public function handle(Installed $event): void
-    {
-        if ($event->initialInstall && !config()->get('panel.email.send_install_notification', true)) {
-            return;
-        }
-
-        if (!$event->initialInstall && !config()->get('panel.email.send_reinstall_notification', true)) {
-            return;
-        }
-
-        if ($event->successful) {
-            $event->server->loadMissing('user');
-
-            $this->server = $event->server;
-            $this->user = $event->server->user;
-
-            // Since we are calling this notification directly from an event listener we need to fire off the dispatcher
-            // to send the email now. Don't use send() or you'll end up firing off two different events.
-            Container::getInstance()->make(Dispatcher::class)->sendNow($this->user, $this);
-        }
-    }
-
-    /**
-     * Get the notification's delivery channels.
-     */
     public function via(): array
     {
         return ['mail'];
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
-    public function toMail(): MailMessage
+    public function toMail(User $notifiable): MailMessage
     {
         return (new MailMessage())
-            ->greeting('Hello ' . $this->user->username . '.')
+            ->greeting('Hello ' . $notifiable->username . '.')
             ->line('Your server has finished installing and is now ready for you to use.')
             ->line('Server Name: ' . $this->server->name)
             ->action('Login and Begin Using', ListServers::getUrl());

--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -42,6 +42,7 @@ class UserCreationService
         $isRootAdmin = array_key_exists('root_admin', $data) && $data['root_admin'];
         unset($data['root_admin']);
 
+        /** @var User $user */
         $user = User::query()->forceCreate(array_merge($data, [
             'uuid' => Uuid::uuid4()->toString(),
         ]));
@@ -55,7 +56,8 @@ class UserCreationService
         }
 
         $this->connection->commit();
-        $user->notify(new AccountCreated($user, $token ?? null));
+
+        $user->notify(new AccountCreated($token ?? null));
 
         return $user;
     }


### PR DESCRIPTION
Laravel only listens for events in the Listener folder. So notifications for server installation and subusers never got sent.