### PR TITLE
Add `isAdmin` check to `SelectableRecord` in `ListUsers`

### DIFF
--- a/app/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
@@ -64,7 +64,7 @@ class ListUsers extends ListRecords
             ->actions([
                 EditAction::make(),
             ])
-            ->checkIfRecordIsSelectableUsing(fn (User $user) => auth()->user()->id !== $user->id && !$user->servers_count)
+            ->checkIfRecordIsSelectableUsing(fn (User $user) => auth()->user()->id !== $user->id && !$user->servers_count && !$user->isAdmin())
             ->bulkActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make()


### PR DESCRIPTION
No one should be able to delete any RootAdmin user from the panel.

>Converted to Draft cause this Policy should already handle it
https://github.com/pelican-dev/panel/blob/9ec2f6eae1a2764377d58dc610f49aa20ecbf711/app/Models/User.php#L400-L407