### PR TITLE
Fix `Admin Area` `translations`

### DIFF
--- a/app/Checks/NodeVersionsCheck.php
+++ b/app/Checks/NodeVersionsCheck.php
@@ -19,7 +19,7 @@ class NodeVersionsCheck extends Check
         if ($all === 0) {
             $result = Result::make()
                 ->notificationMessage(trans('admin/health.results.nodeversions.no_nodes_created'))
-                ->shortSummary(trans('admin/health.results.node_version.no_nodes'));
+                ->shortSummary(trans('admin/health.results.nodeversions.no_nodes'));
             $result->status = Status::skipped();
 
             return $result;

--- a/app/Console/Commands/User/DisableTwoFactorCommand.php
+++ b/app/Console/Commands/User/DisableTwoFactorCommand.php
@@ -19,7 +19,7 @@ class DisableTwoFactorCommand extends Command
     public function handle(): void
     {
         if ($this->input->isInteractive()) {
-            $this->output->warning(trans('command/messages.user.2fa_help_text'));
+            $this->output->warning(trans('command/messages.user.2fa_help_text.0') . trans('command/messages.user.2fa_help_text.1'));
         }
 
         $email = $this->option('email') ?? $this->ask(trans('command/messages.user.ask_email'));

--- a/app/Filament/Admin/Resources/NodeResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Admin/Resources/NodeResource/RelationManagers/AllocationsRelationManager.php
@@ -73,7 +73,7 @@ class AllocationsRelationManager extends RelationManager
             ])
             ->headerActions([
                 Tables\Actions\Action::make('create new allocation')
-                    ->label(trans('admin/node.create_allocations'))
+                    ->label(trans('admin/node.create_allocation'))
                     ->form(fn () => [
                         Select::make('allocation_ip')
                             ->options(collect($this->getOwnerRecord()->ipAddresses())->mapWithKeys(fn (string $ip) => [$ip => $ip]))

--- a/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
@@ -139,21 +139,21 @@ class CreateServer extends CreateRecord
                                 ->getOptionLabelFromRecordUsing(fn (User $user) => "$user->email | $user->username " . (blank($user->roles) ? '' : '(' . $user->roles->first()->name . ')'))
                                 ->createOptionForm([
                                     TextInput::make('username')
-                                        ->label(trans('admin/user.edit.username'))
+                                        ->label(trans('admin/user.username'))
                                         ->alphaNum()
                                         ->required()
                                         ->minLength(3)
                                         ->maxLength(255),
 
                                     TextInput::make('email')
-                                        ->label(trans('admin/user.edit.email'))
+                                        ->label(trans('admin/user.email'))
                                         ->email()
                                         ->required()
                                         ->unique()
                                         ->maxLength(255),
 
                                     TextInput::make('password')
-                                        ->label(trans('admin/user.edit.password'))
+                                        ->label(trans('admin/user.password'))
                                         ->hintIcon('tabler-question-mark')
                                         ->hintIconTooltip(trans('admin/user.password_help'))
                                         ->password(),

--- a/app/Filament/Admin/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
+++ b/app/Filament/Admin/Resources/ServerResource/RelationManagers/AllocationsRelationManager.php
@@ -60,7 +60,7 @@ class AllocationsRelationManager extends RelationManager
                     ->label(fn (Allocation $allocation) => $allocation->id === $this->getOwnerRecord()->allocation_id ? '' : trans('admin/server.make_primary')),
             ])
             ->headerActions([
-                CreateAction::make()->label(trans('admin/node.create_allocations'))
+                CreateAction::make()->label(trans('admin/server.create_allocation'))
                     ->createAnother(false)
                     ->form(fn () => [
                         Select::make('allocation_ip')
@@ -94,7 +94,7 @@ class AllocationsRelationManager extends RelationManager
                     ->preloadRecordSelect()
                     ->recordSelectOptionsQuery(fn ($query) => $query->whereBelongsTo($this->getOwnerRecord()->node)->whereNull('server_id'))
                     ->recordSelectSearchColumns(['ip', 'port'])
-                    ->label(trans('admin/server.add_allocations')),
+                    ->label(trans('admin/server.add_allocation')),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Admin/Resources/WebhookResource/Pages/CreateWebhookConfiguration.php
+++ b/app/Filament/Admin/Resources/WebhookResource/Pages/CreateWebhookConfiguration.php
@@ -32,14 +32,14 @@ class CreateWebhookConfiguration extends CreateRecord
         return $form
             ->schema([
                 TextInput::make('endpoint')
-                    ->label(trans('admin/webhooks.endpoint'))
+                    ->label(trans('admin/webhook.endpoint'))
                     ->activeUrl()
                     ->required(),
                 TextInput::make('description')
-                    ->label(trans('admin/webhooks.description'))
+                    ->label(trans('admin/webhook.description'))
                     ->required(),
                 CheckboxList::make('events')
-                    ->label(trans('admin/webhooks.events'))
+                    ->label(trans('admin/webhook.events'))
                     ->lazy()
                     ->options(fn () => WebhookConfiguration::filamentCheckboxList())
                     ->searchable()

--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -116,7 +116,7 @@ class EditProfile extends BaseEditProfile
                                             ->prefixIcon('tabler-flag')
                                             ->live()
                                             ->default('en')
-                                            ->helperText(fn ($state, LanguageService $languageService) => new HtmlString($languageService->isLanguageTranslated($state) ? '' : trans('profile.language_helper', ['state' => $state])))
+                                            ->helperText(fn ($state, LanguageService $languageService) => new HtmlString($languageService->isLanguageTranslated($state) ? '' : trans('profile.language_help', ['state' => $state])))
                                             ->options(fn (LanguageService $languageService) => $languageService->getAvailableLanguages()),
                                     ]),
 

--- a/app/Filament/Server/Resources/UserResource.php
+++ b/app/Filament/Server/Resources/UserResource.php
@@ -458,7 +458,7 @@ class UserResource extends Resource
                                                             ->descriptions([
                                                                 'rename' => trans('server/users.permissions.setting_rename'),
                                                                 'reinstall' => trans('server/users.permissions.setting_reinstall'),
-                                                                'activity' => trans('server/users.permissions.setting_activity'),
+                                                                'activity' => trans('server/users.permissions.activity_desc'),
                                                             ]),
                                                     ]),
                                             ]),

--- a/app/Filament/Server/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Server/Resources/UserResource/Pages/ListUsers.php
@@ -355,7 +355,7 @@ class ListUsers extends ListRecords
                                                         ->descriptions([
                                                             'rename' => trans('server/users.permissions.setting_rename'),
                                                             'reinstall' => trans('server/users.permissions.setting_reinstall'),
-                                                            'activity' => trans('server/users.permissions.setting_activity'),
+                                                            'activity' => trans('server/users.permissions.activity_desc'),
                                                         ]),
                                                 ]),
                                         ]),

--- a/app/Services/Servers/ToggleInstallService.php
+++ b/app/Services/Servers/ToggleInstallService.php
@@ -10,7 +10,7 @@ class ToggleInstallService
     public function handle(Server $server): void
     {
         if ($server->status === ServerState::InstallFailed) {
-            abort(500, trans('admin/server.exceptions.marked_as_failed'));
+            abort(500, trans('exceptions.server.marked_as_failed'));
         }
 
         $server->status = $server->isInstalled() ? ServerState::Installing : null;

--- a/lang/en/admin/databasehost.php
+++ b/lang/en/admin/databasehost.php
@@ -22,7 +22,7 @@ return [
     'host' => 'Host',
     'host_help' => 'The IP address or Domain name that should be used when attempting to connect to this MySQL host from this Panel to create new databases.',
     'port' => 'Port',
-    'post_help' => 'The port that MySQL is running on for this host.',
+    'port_help' => 'The port that MySQL is running on for this host.',
     'max_database' => 'Max Databases',
     'max_databases_help' => 'The maximum number of databases that can be created on this host. If the limit is reached, no new databases can be created on this host. Blank is unlimited.',
     'display_name' => 'Display Name',

--- a/lang/en/admin/node.php
+++ b/lang/en/admin/node.php
@@ -95,7 +95,7 @@ return [
 
     'next_step' => 'Next Step',
     'node_has_servers' => 'Node Has Servers',
-    'create_allocations' => 'Create Allocations',
+    'create_allocation' => 'Create Allocation',
     'primary_allocation' => 'Primary Allocation',
     'databases' => 'Databases',
     'backups' => 'Backups',

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -95,6 +95,7 @@ return [
     'change_egg' => 'Change Egg',
     'new_egg' => 'New Egg',
     'keep_old_variables' => 'Keep old variables if possible?',
+    'create_allocation' => 'Create Allocation',
     'add_allocation' => 'Add Allocation',
     'view' => 'View',
     'tabs' => [

--- a/lang/en/exceptions.php
+++ b/lang/en/exceptions.php
@@ -57,5 +57,5 @@ return [
     ],
     'server' => [
         'marked_as_failed' => 'This server has not yet completed its installation process, please try again later.',
-    ]
+    ],
 ];

--- a/lang/en/exceptions.php
+++ b/lang/en/exceptions.php
@@ -55,4 +55,7 @@ return [
     'mount' => [
         'servers_attached' => 'A mount must have no servers attached to it in order to be deleted.',
     ],
+    'server' => [
+        'marked_as_failed' => 'This server has not yet completed its installation process, please try again later.',
+    ]
 ];


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8109d316-f45d-4b77-82aa-b3f7bb6d9e42)
All those were broken.

_I really need to switch to phpStorm im fed up with VSCode's terminal glitchs causing garbage commit names_