### PR TITLE
Small translation fixes

### DIFF
--- a/app/Filament/Admin/Resources/ApiKeyResource/Pages/ListApiKeys.php
+++ b/app/Filament/Admin/Resources/ApiKeyResource/Pages/ListApiKeys.php
@@ -58,7 +58,6 @@ class ListApiKeys extends ListRecords
             ->emptyStateHeading(trans('admin/apikey.empty_table'))
             ->emptyStateActions([
                 CreateAction::make('create')
-                    ->label(trans('admin/apikey.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                     ->button(),
             ]);
     }
@@ -67,7 +66,6 @@ class ListApiKeys extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label(trans('admin/apikey.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                 ->hidden(fn () => ApiKey::where('key_type', ApiKey::TYPE_APPLICATION)->count() <= 0),
         ];
     }

--- a/app/Filament/Admin/Resources/DatabaseHostResource/Pages/ListDatabaseHosts.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource/Pages/ListDatabaseHosts.php
@@ -59,7 +59,6 @@ class ListDatabaseHosts extends ListRecords
             ->emptyStateHeading(trans('admin/databasehost.no_database_hosts'))
             ->emptyStateActions([
                 CreateAction::make('create')
-                    ->label(trans('admin/databasehost.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                     ->button(),
             ]);
     }
@@ -68,7 +67,6 @@ class ListDatabaseHosts extends ListRecords
     {
         return [
             Actions\CreateAction::make('create')
-                ->label(trans('admin/databasehost.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                 ->hidden(fn () => DatabaseHost::count() <= 0),
         ];
     }

--- a/app/Filament/Admin/Resources/EggResource/Pages/ListEggs.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/ListEggs.php
@@ -58,8 +58,7 @@ class ListEggs extends ListRecords
             ->emptyStateDescription('')
             ->emptyStateHeading(trans('admin/egg.no_eggs'))
             ->emptyStateActions([
-                CreateAction::make()
-                    ->label(trans('admin/egg.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')])),
+                CreateAction::make(),
                 ImportEggAction::make(),
             ]);
     }
@@ -68,8 +67,7 @@ class ListEggs extends ListRecords
     {
         return [
             ImportEggHeaderAction::make(),
-            CreateHeaderAction::make()
-                ->label(trans('admin/egg.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')])),
+            CreateHeaderAction::make(),
         ];
     }
 }

--- a/app/Filament/Admin/Resources/MountResource/Pages/ListMounts.php
+++ b/app/Filament/Admin/Resources/MountResource/Pages/ListMounts.php
@@ -52,7 +52,6 @@ class ListMounts extends ListRecords
             ->emptyStateHeading(trans('admin/mount.no_mounts'))
             ->emptyStateActions([
                 CreateAction::make('create')
-                    ->label(trans('admin/mount.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                     ->button(),
             ]);
     }
@@ -61,7 +60,6 @@ class ListMounts extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label(trans('admin/mount.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                 ->hidden(fn () => Mount::count() <= 0),
         ];
     }

--- a/app/Filament/Admin/Resources/NodeResource/Pages/ListNodes.php
+++ b/app/Filament/Admin/Resources/NodeResource/Pages/ListNodes.php
@@ -65,7 +65,6 @@ class ListNodes extends ListRecords
             ->emptyStateHeading(trans('admin/node.no_nodes'))
             ->emptyStateActions([
                 CreateAction::make('create')
-                    ->label(trans('admin/node.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                     ->button(),
             ]);
     }
@@ -74,7 +73,6 @@ class ListNodes extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label(trans('admin/node.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                 ->hidden(fn () => Node::count() <= 0),
         ];
     }

--- a/app/Filament/Admin/Resources/RoleResource/Pages/ListRoles.php
+++ b/app/Filament/Admin/Resources/RoleResource/Pages/ListRoles.php
@@ -53,8 +53,7 @@ class ListRoles extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            CreateAction::make()
-                ->label(trans('admin/role.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')])),
+            CreateAction::make(),
         ];
     }
 }

--- a/app/Filament/Admin/Resources/ServerResource/Pages/ListServers.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/ListServers.php
@@ -98,7 +98,6 @@ class ListServers extends ListRecords
             ->emptyStateHeading(trans('admin/server.no_servers'))
             ->emptyStateActions([
                 CreateAction::make('create')
-                    ->label(trans('admin/server.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                     ->button(),
             ]);
     }
@@ -107,7 +106,6 @@ class ListServers extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label(trans('admin/server.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                 ->hidden(fn () => Server::count() <= 0),
         ];
     }

--- a/app/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Admin/Resources/UserResource/Pages/ListUsers.php
@@ -78,8 +78,7 @@ class ListUsers extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            CreateAction::make()
-                ->label(trans('admin/user.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')])),
+            CreateAction::make(),
         ];
     }
 }

--- a/app/Filament/Admin/Resources/WebhookResource/Pages/ListWebhookConfigurations.php
+++ b/app/Filament/Admin/Resources/WebhookResource/Pages/ListWebhookConfigurations.php
@@ -34,7 +34,6 @@ class ListWebhookConfigurations extends ListRecords
             ->emptyStateHeading(trans('admin/webhook.no_webhooks'))
             ->emptyStateActions([
                 CreateAction::make('create')
-                    ->label(trans('admin/webhook.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                     ->button(),
             ]);
     }
@@ -43,7 +42,6 @@ class ListWebhookConfigurations extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label(trans('admin/webhook.create_action', ['action' => trans('filament-actions::create.single.modal.actions.create.label')]))
                 ->hidden(fn () => WebhookConfiguration::count() <= 0),
         ];
     }

--- a/lang/en/admin/apikey.php
+++ b/lang/en/admin/apikey.php
@@ -10,7 +10,6 @@ return [
     'nav_title' => 'API Keys',
     'model_label' => 'Application API Key',
     'model_label_plural' => 'Application API Keys',
-    'create_action' => ':action API Key',
     'table' => [
         'key' => 'Key',
         'description' => 'Description',

--- a/lang/en/admin/databasehost.php
+++ b/lang/en/admin/databasehost.php
@@ -25,7 +25,7 @@ return [
     'max_database' => 'Max Databases',
     'max_databases_help' => 'The maximum number of databases that can be created on this host. If the limit is reached, no new databases can be created on this host. Blank is unlimited.',
     'display_name' => 'Display Name',
-    'display_name_help' => 'A short identifier used to distinguish this node from others. Must be between 1 and 60 characters, for example, us.nyc.lvl3.',
+    'display_name_help' => 'A short identifier used to distinguish this host from others. Must be between 1 and 60 characters, for example, us.nyc.lvl3.',
     'username' => 'Username',
     'username_help' => 'The username of an account that has enough permissions to create new users and databases on the system.',
     'password' => 'Password',

--- a/lang/en/admin/databasehost.php
+++ b/lang/en/admin/databasehost.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'create_action' => ':action Database host',
     'nav_title' => 'Database Hosts',
     'model_label' => 'Database Host',
     'model_label_plural' => 'Database Hosts',

--- a/lang/en/admin/databasehost.php
+++ b/lang/en/admin/databasehost.php
@@ -26,7 +26,7 @@ return [
     'max_database' => 'Max Databases',
     'max_databases_help' => 'The maximum number of databases that can be created on this host. If the limit is reached, no new databases can be created on this host. Blank is unlimited.',
     'display_name' => 'Display Name',
-    'display_name_help' => 'A short identifier used to distinguish this location from others. Must be between 1 and 60 characters, for example, us.nyc.lvl3.',
+    'display_name_help' => 'A short identifier used to distinguish this node from others. Must be between 1 and 60 characters, for example, us.nyc.lvl3.',
     'username' => 'Username',
     'username_help' => 'The username of an account that has enough permissions to create new users and databases on the system.',
     'password' => 'Password',

--- a/lang/en/admin/egg.php
+++ b/lang/en/admin/egg.php
@@ -19,7 +19,6 @@ return [
         'import_success' => 'Import Success',
     ],
     'in_use' => 'In Use',
-    'create_action' => ':action Egg',
     'servers' => 'Servers',
     'name' => 'Name',
     'egg_uuid' => 'Egg UUID',

--- a/lang/en/admin/mount.php
+++ b/lang/en/admin/mount.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'create_action' => ':action Mount',
     'nav_title' => 'Mounts',
     'model_label' => 'Mount',
     'model_label_plural' => 'Mounts',

--- a/lang/en/admin/node.php
+++ b/lang/en/admin/node.php
@@ -4,7 +4,6 @@ return [
     'nav_title' => 'Nodes',
     'model_label' => 'Node',
     'model_label_plural' => 'Nodes',
-    'create_action' => ':action Node',
     'tabs' => [
         'overview' => 'Overview',
         'basic_settings' => 'Basic Settings',

--- a/lang/en/admin/role.php
+++ b/lang/en/admin/role.php
@@ -4,7 +4,6 @@ return [
     'nav_title' => 'Roles',
     'model_label' => 'Role',
     'model_label_plural' => 'Roles',
-    'create_action' => ':action Role',
     'no_roles' => 'No Roles',
     'name' => 'Role Name',
     'permissions' => 'Permissions',

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'create_action' => ':action Server',
     'nav_title' => 'Servers',
     'model_label' => 'Server',
     'model_label_plural' => 'Servers',

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -30,7 +30,7 @@ return [
     'resource_limits' => 'Resource Limits',
     'cpu' => 'CPU',
     'cpu_limit' => 'CPU Limit',
-    'cpu_helper' => '100% equals one CPU core.',
+    'cpu_helper' => '100% equals one CPU thread.',
     'unlimited' => 'Unlimited',
     'limited' => 'Limited',
     'enabled' => 'Enabled',

--- a/lang/en/admin/user.php
+++ b/lang/en/admin/user.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'create_action' => ':action User',
     'nav_title' => 'Users',
     'model_label' => 'User',
     'model_label_plural' => 'Users',

--- a/lang/en/admin/webhook.php
+++ b/lang/en/admin/webhook.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'create_action' => ':action Webhook',
     'nav_title' => 'Webhooks',
     'model_label' => 'Webhook',
     'model_label_plural' => 'Webhooks',


### PR DESCRIPTION
- Database Host, `display_name_help`: replace `location` with `host`
- Node, `cpu_helper`: 100% is one _thread_, not core
- Remove unnecessary `create_action` translation. Filament translates the create action for us.