### PR TITLE
Fix deleted users being shown as "System" in activity log

### DIFF
--- a/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
+++ b/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
@@ -42,7 +42,11 @@ class ListActivities extends ListRecords
                 TextColumn::make('user')
                     ->state(function (ActivityLog $activityLog) use ($server) {
                         if (!$activityLog->actor instanceof User) {
-                            return 'System';
+                            if ($activityLog->actor_id == null) {
+                                return 'System';
+                            } else {
+                                return 'Deleted user';
+                            }
                         }
 
                         $user = $activityLog->actor->username;
@@ -72,7 +76,11 @@ class ListActivities extends ListRecords
                         TextInput::make('user')
                             ->formatStateUsing(function (ActivityLog $activityLog) use ($server) {
                                 if (!$activityLog->actor instanceof User) {
-                                    return 'System';
+                                    if ($activityLog->actor_id == null) {
+                                        return 'System';
+                                    } else {
+                                        return 'Deleted user';
+                                    }
                                 }
 
                                 $user = $activityLog->actor->username;

--- a/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
+++ b/app/Filament/Server/Resources/ActivityResource/Pages/ListActivities.php
@@ -42,11 +42,7 @@ class ListActivities extends ListRecords
                 TextColumn::make('user')
                     ->state(function (ActivityLog $activityLog) use ($server) {
                         if (!$activityLog->actor instanceof User) {
-                            if ($activityLog->actor_id == null) {
-                                return 'System';
-                            } else {
-                                return 'Deleted user';
-                            }
+                            return $activityLog->actor_id === null ? 'System' : 'Deleted user';
                         }
 
                         $user = $activityLog->actor->username;
@@ -76,11 +72,7 @@ class ListActivities extends ListRecords
                         TextInput::make('user')
                             ->formatStateUsing(function (ActivityLog $activityLog) use ($server) {
                                 if (!$activityLog->actor instanceof User) {
-                                    if ($activityLog->actor_id == null) {
-                                        return 'System';
-                                    } else {
-                                        return 'Deleted user';
-                                    }
+                                    return $activityLog->actor_id === null ? 'System' : 'Deleted user';
                                 }
 
                                 $user = $activityLog->actor->username;

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -157,7 +157,7 @@ class ActivityLog extends Model implements HasIcon, HasLabel
             return 'tabler-user';
         }
 
-        return $this->actor_id !== null ? 'tabler-user-off' : 'tabler-device-desktop';
+        return $this->actor_id === null ? 'tabler-device-desktop' : 'tabler-user-off';
     }
 
     public function getLabel(): string

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -153,7 +153,11 @@ class ActivityLog extends Model implements HasIcon, HasLabel
             return 'tabler-api';
         }
 
-        return $this->actor instanceof User ? 'tabler-user' : 'tabler-device-desktop';
+        if ($this->actor instanceof User) {
+            return 'tabler-user';
+        }
+
+        return $this->actor_id !== null ? 'tabler-user-off' : 'tabler-device-desktop';
     }
 
     public function getLabel(): string


### PR DESCRIPTION
Shows deleted users as "Deleted user" and changes their icon to "user-off"

![image](https://github.com/user-attachments/assets/745354bd-8667-417e-8970-29e77e0d5446)

Closes #569 