### PR TITLE
(docker) supercronic: allow overlapping

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -41,7 +41,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:supercronic]
-command=supercronic /etc/supercronic/crontab
+command=supercronic -overlapping /etc/supercronic/crontab
 autostart=true
 autorestart=true
 redirect_stderr=true


### PR DESCRIPTION
# Changes

- start supercronic what runs the schedule to allow for jobs to overlap.  This was causing the healtcheck to say that the schedule did not ran, and it would only run every 2 minutes instead of every minute

```log
DEBU[2025-02-16T15:29:00Z] job will run next at 2025-02-16 15:29:00 +0000 UTC  job.command="php /var/www/html/artisan schedule:run" job.position=0 job.schedule="* * * * *"
WARN[2025-02-16T15:29:00Z] job took too long to run: it should have started 76.963883ms ago  job.command="php /var/www/html/artisan schedule:run" job.position=0 job.schedule="* * * * *"
DEBU[2025-02-16T15:29:00Z] job will run next at 2025-02-16 15:30:00 +0000 UTC  job.command="php /var/www/html/artisan schedule:run" job.position=0 job.schedule="* * * * *"
```

Before:
![afbeelding](https://github.com/user-attachments/assets/01444276-5c2a-41d2-b4cb-3b207a8004a4)

After:
![afbeelding](https://github.com/user-attachments/assets/847900ee-e719-4a32-903f-19e650fb8133)
