### PR TITLE
Validate eggVariable `default_value` using its `rules`

### DIFF
--- a/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
@@ -201,6 +201,7 @@ class CreateEgg extends CreateRecord
                                         ->required(),
                                     TextInput::make('default_value')
                                         ->label(trans('admin/egg.default_value'))
+                                        ->required(fn (Get $get) => in_array('required', $get('rules')))
                                         ->rules(fn (Get $get) => $get('rules'))
                                         ->maxLength(255),
                                     Fieldset::make(trans('admin/egg.user_permissions'))
@@ -212,6 +213,7 @@ class CreateEgg extends CreateRecord
                                         ->label(trans('admin/egg.rules'))
                                         ->columnSpanFull()
                                         ->reorderable()
+                                        ->live()
                                         ->suggestions([
                                             'required',
                                             'nullable',

--- a/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
@@ -199,7 +199,10 @@ class CreateEgg extends CreateRecord
                                             '*' => trans('admin/egg.error_reserved'),
                                         ])
                                         ->required(),
-                                    TextInput::make('default_value')->label(trans('admin/egg.default_value'))->maxLength(255),
+                                    TextInput::make('default_value')
+                                        ->label(trans('admin/egg.default_value'))
+                                        ->rules(fn (Get $get) => $get('rules'))
+                                        ->maxLength(255),
                                     Fieldset::make(trans('admin/egg.user_permissions'))
                                         ->schema([
                                             Checkbox::make('user_viewable')->label(trans('admin/egg.viewable')),

--- a/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
@@ -190,7 +190,10 @@ class EditEgg extends EditRecord
                                             '*' => trans('admin/egg.error_reserved'),
                                         ])
                                         ->required(),
-                                    TextInput::make('default_value')->label(trans('admin/egg.default_value'))->maxLength(255),
+                                    TextInput::make('default_value')
+                                        ->label(trans('admin/egg.default_value'))
+                                        ->rules(fn (Get $get) => $get('rules'))
+                                        ->maxLength(255),
                                     Fieldset::make(trans('admin/egg.user_permissions'))
                                         ->schema([
                                             Checkbox::make('user_viewable')->label(trans('admin/egg.viewable')),

--- a/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
@@ -192,6 +192,7 @@ class EditEgg extends EditRecord
                                         ->required(),
                                     TextInput::make('default_value')
                                         ->label(trans('admin/egg.default_value'))
+                                        ->required(fn (Get $get) => in_array('required', $get('rules')))
                                         ->rules(fn (Get $get) => $get('rules'))
                                         ->maxLength(255),
                                     Fieldset::make(trans('admin/egg.user_permissions'))
@@ -203,6 +204,7 @@ class EditEgg extends EditRecord
                                         ->label(trans('admin/egg.rules'))
                                         ->columnSpanFull()
                                         ->reorderable()
+                                        ->live()
                                         ->suggestions([
                                             'required',
                                             'nullable',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/475fbabb-51db-41a9-8912-8d7625e1298b)
![image](https://github.com/user-attachments/assets/756d0388-b72a-46c5-bc3d-6bdfe9e33010)
![image](https://github.com/user-attachments/assets/dfb3feb3-2f36-4ac9-8bb1-33745be847cb)

I know about but i need it raw otherwise you have to save first.
https://github.com/pelican-dev/panel/blob/324fc4b7d57d27e7b20ebcae9686af94ba2f0faa/app/Models/EggVariable.php#L85-L88