### PR TITLE
Fix `Node` Edit Page

### DIFF
--- a/app/Filament/Admin/Resources/NodeResource/Pages/CreateNode.php
+++ b/app/Filament/Admin/Resources/NodeResource/Pages/CreateNode.php
@@ -250,6 +250,7 @@ class CreateNode extends CreateRecord
                                 ->columnSpanFull()
                                 ->schema([
                                     ToggleButtons::make('unlimited_mem')
+                                        ->dehydrated()
                                         ->label(trans('admin/node.memory'))->inlineLabel()->inline()
                                         ->afterStateUpdated(fn (Set $set) => $set('memory', 0))
                                         ->afterStateUpdated(fn (Set $set) => $set('memory_overallocate', 0))
@@ -291,6 +292,7 @@ class CreateNode extends CreateRecord
                                 ->columnSpanFull()
                                 ->schema([
                                     ToggleButtons::make('unlimited_disk')
+                                        ->dehydrated()
                                         ->label(trans('admin/node.disk'))->inlineLabel()->inline()
                                         ->live()
                                         ->afterStateUpdated(fn (Set $set) => $set('disk', 0))
@@ -332,6 +334,7 @@ class CreateNode extends CreateRecord
                                 ->columnSpanFull()
                                 ->schema([
                                     ToggleButtons::make('unlimited_cpu')
+                                        ->dehydrated()
                                         ->label(trans('admin/node.cpu'))->inlineLabel()->inline()
                                         ->live()
                                         ->afterStateUpdated(fn (Set $set) => $set('cpu', 0))

--- a/app/Filament/Admin/Resources/NodeResource/Pages/EditNode.php
+++ b/app/Filament/Admin/Resources/NodeResource/Pages/EditNode.php
@@ -343,6 +343,7 @@ class EditNode extends EditRecord
                                 ->columnSpanFull()
                                 ->schema([
                                     ToggleButtons::make('unlimited_mem')
+                                        ->dehydrated()
                                         ->label(trans('admin/node.memory'))->inlineLabel()->inline()
                                         ->afterStateUpdated(fn (Set $set) => $set('memory', 0))
                                         ->afterStateUpdated(fn (Set $set) => $set('memory_overallocate', 0))
@@ -401,6 +402,7 @@ class EditNode extends EditRecord
                                 ])
                                 ->schema([
                                     ToggleButtons::make('unlimited_disk')
+                                        ->dehydrated()
                                         ->label(trans('admin/node.disk'))->inlineLabel()->inline()
                                         ->live()
                                         ->afterStateUpdated(fn (Set $set) => $set('disk', 0))
@@ -455,6 +457,7 @@ class EditNode extends EditRecord
                                 ->columnSpanFull()
                                 ->schema([
                                     ToggleButtons::make('unlimited_cpu')
+                                        ->dehydrated()
                                         ->label(trans('admin/node.cpu'))->inlineLabel()->inline()
                                         ->live()
                                         ->afterStateUpdated(fn (Set $set) => $set('cpu', 0))
@@ -589,8 +592,6 @@ class EditNode extends EditRecord
         }
 
         try {
-            unset($data['unlimited_mem'], $data['unlimited_disk'], $data['unlimited_cpu']);
-
             $this->record = $this->nodeUpdateService->handle($record, $data);
 
             return $this->record;

--- a/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
@@ -499,6 +499,7 @@ class CreateServer extends CreateRecord
                                         ->columnSpanFull()
                                         ->schema([
                                             ToggleButtons::make('unlimited_cpu')
+                                                ->dehydrated()
                                                 ->label(trans('admin/server.cpu'))->inlineLabel()->inline()
                                                 ->default(true)
                                                 ->afterStateUpdated(fn (Set $set) => $set('cpu', 0))
@@ -530,6 +531,7 @@ class CreateServer extends CreateRecord
                                         ->columnSpanFull()
                                         ->schema([
                                             ToggleButtons::make('unlimited_mem')
+                                                ->dehydrated()
                                                 ->label(trans('admin/server.memory'))->inlineLabel()->inline()
                                                 ->default(true)
                                                 ->afterStateUpdated(fn (Set $set) => $set('memory', 0))
@@ -560,6 +562,7 @@ class CreateServer extends CreateRecord
                                         ->columnSpanFull()
                                         ->schema([
                                             ToggleButtons::make('unlimited_disk')
+                                                ->dehydrated()
                                                 ->label(trans('admin/server.disk'))->inlineLabel()->inline()
                                                 ->default(true)
                                                 ->live()
@@ -696,9 +699,6 @@ class CreateServer extends CreateRecord
                                                     false => 'success',
                                                     true => 'danger',
                                                 ]),
-
-                                            TextInput::make('oom_disabled_hidden')
-                                                ->hidden(),
                                         ]),
                                 ]),
 

--- a/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
@@ -195,6 +195,7 @@ class EditServer extends EditRecord
                                             ->columnSpanFull()
                                             ->schema([
                                                 ToggleButtons::make('unlimited_cpu')
+                                                    ->dehydrated()
                                                     ->label(trans('admin/server.cpu'))->inlineLabel()->inline()
                                                     ->afterStateUpdated(fn (Set $set) => $set('cpu', 0))
                                                     ->formatStateUsing(fn (Get $get) => $get('cpu') == 0)
@@ -224,6 +225,7 @@ class EditServer extends EditRecord
                                             ->columnSpanFull()
                                             ->schema([
                                                 ToggleButtons::make('unlimited_mem')
+                                                    ->dehydrated()
                                                     ->label(trans('admin/server.memory'))->inlineLabel()->inline()
                                                     ->afterStateUpdated(fn (Set $set) => $set('memory', 0))
                                                     ->formatStateUsing(fn (Get $get) => $get('memory') == 0)
@@ -254,6 +256,7 @@ class EditServer extends EditRecord
                                             ->columnSpanFull()
                                             ->schema([
                                                 ToggleButtons::make('unlimited_disk')
+                                                    ->dehydrated()
                                                     ->label(trans('admin/server.disk'))->inlineLabel()->inline()
                                                     ->live()
                                                     ->afterStateUpdated(fn (Set $set) => $set('disk', 0))
@@ -388,9 +391,6 @@ class EditServer extends EditRecord
                                                         false => 'success',
                                                         true => 'danger',
                                                     ]),
-
-                                                TextInput::make('oom_disabled_hidden')
-                                                    ->hidden(),
                                             ]),
                                     ]),
 


### PR DESCRIPTION
Without those once you set limit you can't get rid of them + overallocate couldn't be `0` it would either be `-1` or a positive number
Remove useless `oom_disabled_hidden` field