### PR TITLE
Call parent constructor in custom oauth provider classes

### DIFF
--- a/app/Extensions/OAuth/Providers/AuthentikProvider.php
+++ b/app/Extensions/OAuth/Providers/AuthentikProvider.php
@@ -9,7 +9,10 @@ use SocialiteProviders\Authentik\Provider;
 
 final class AuthentikProvider extends OAuthProvider
 {
-    public function __construct(protected Application $app) {}
+    public function __construct(protected Application $app)
+    {
+        parent::__construct($app);
+    }
 
     public function getId(): string
     {

--- a/app/Extensions/OAuth/Providers/DiscordProvider.php
+++ b/app/Extensions/OAuth/Providers/DiscordProvider.php
@@ -13,7 +13,10 @@ use Webbingbrasil\FilamentCopyActions\Forms\Actions\CopyAction;
 
 final class DiscordProvider extends OAuthProvider
 {
-    public function __construct(protected Application $app) {}
+    public function __construct(protected Application $app)
+    {
+        parent::__construct($app);
+    }
 
     public function getId(): string
     {

--- a/app/Extensions/OAuth/Providers/GithubProvider.php
+++ b/app/Extensions/OAuth/Providers/GithubProvider.php
@@ -12,7 +12,10 @@ use Webbingbrasil\FilamentCopyActions\Forms\Actions\CopyAction;
 
 final class GithubProvider extends OAuthProvider
 {
-    public function __construct(protected Application $app) {}
+    public function __construct(protected Application $app)
+    {
+        parent::__construct($app);
+    }
 
     public function getId(): string
     {

--- a/app/Extensions/OAuth/Providers/SteamProvider.php
+++ b/app/Extensions/OAuth/Providers/SteamProvider.php
@@ -11,7 +11,10 @@ use SocialiteProviders\Steam\Provider;
 
 final class SteamProvider extends OAuthProvider
 {
-    public function __construct(protected Application $app) {}
+    public function __construct(protected Application $app)
+    {
+        parent::__construct($app);
+    }
 
     public function getId(): string
     {


### PR DESCRIPTION
Without the parent constructor the provider isn't registered properly.