### PR TITLE
Use `predis` as default redis driver

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -120,7 +120,7 @@ return [
 
     'redis' => [
 
-        'client' => env('REDIS_CLIENT', 'phpredis'),
+        'client' => env('REDIS_CLIENT', 'predis'),
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),


### PR DESCRIPTION
You need the `php-redis` package to use phpredis so it shouldn't be the default.
https://github.com/pelican-dev/panel/pull/1045/files#r1976683413