### PR TITLE
Add hint about overhead when using memory limit

### DIFF
--- a/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
@@ -551,6 +551,8 @@ class CreateServer extends CreateRecord
                                                 ->hidden(fn (Get $get) => $get('unlimited_mem'))
                                                 ->label(trans('admin/server.memory_limit'))->inlineLabel()
                                                 ->suffix(config('panel.use_binary_prefix') ? 'MiB' : 'MB')
+                                                ->hintIcon('tabler-question-mark')
+                                                ->hintIconToolTip(trans('admin/server.memory_helper'))
                                                 ->default(0)
                                                 ->required()
                                                 ->columnSpan(2)

--- a/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
@@ -248,6 +248,8 @@ class EditServer extends EditRecord
                                                     ->hidden(fn (Get $get) => $get('unlimited_mem'))
                                                     ->label(trans('admin/server.memory_limit'))->inlineLabel()
                                                     ->suffix(config('panel.use_binary_prefix') ? 'MiB' : 'MB')
+                                                    ->hintIcon('tabler-question-mark')
+                                                    ->hintIconToolTip(trans('admin/server.memory_helper'))
                                                     ->required()
                                                     ->columnSpan(2)
                                                     ->numeric()

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -36,6 +36,7 @@ return [
     'disabled' => 'Disabled',
     'memory' => 'Memory',
     'memory_limit' => 'Memory Limit',
+    'memory_helper' => 'Wings will add overhead to this value when creating the container. <=2048MB = +10%, <=4069MB = +15%, anything else = +5%',
     'disk' => 'Disk Space',
     'disk_limit' => 'Disk Space Limit',
     'advanced_limits' => 'Advanced Limits',

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -36,7 +36,7 @@ return [
     'disabled' => 'Disabled',
     'memory' => 'Memory',
     'memory_limit' => 'Memory Limit',
-    'memory_helper' => 'Wings will add overhead to this value when creating the container to make sure it doesn't starve out when using max memory.',
+    'memory_helper' => 'Wings will add overhead to this value when creating the container to make sure it doesn\'t starve out when using max memory.',
     'disk' => 'Disk Space',
     'disk_limit' => 'Disk Space Limit',
     'advanced_limits' => 'Advanced Limits',

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -36,7 +36,7 @@ return [
     'disabled' => 'Disabled',
     'memory' => 'Memory',
     'memory_limit' => 'Memory Limit',
-    'memory_helper' => 'Wings will add overhead to this value when creating the container. <=2048MB = +10%, <=4069MB = +15%, anything else = +5%',
+    'memory_helper' => 'Wings will add overhead to this value when creating the container to make sure it doesn't starve out when using max memory.',
     'disk' => 'Disk Space',
     'disk_limit' => 'Disk Space Limit',
     'advanced_limits' => 'Advanced Limits',


### PR DESCRIPTION
Add hint about overhead as it's not documented anywhere except in the wings source code. 