### PR TITLE
Fix null `Node` `Stats`

### DIFF
--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -364,6 +364,10 @@ class Node extends Model implements Validatable
         ];
 
         try {
+            (new DaemonConfigurationRepository())
+                ->setNode($this)
+                ->getSystemInformation();
+
             return Http::daemon($this)
                 ->connectTimeout(1)
                 ->timeout(1)

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -364,9 +364,7 @@ class Node extends Model implements Validatable
         ];
 
         try {
-            (new DaemonConfigurationRepository())
-                ->setNode($this)
-                ->getSystemInformation();
+            $this->systemInformation();
 
             return Http::daemon($this)
                 ->connectTimeout(1)


### PR DESCRIPTION
Happened if you were talking to the wrong instance of wings (token missmatch) or any other reachable website that wouldn't timeout.