### PR TITLE
Fix missing space in `OAuth` modal

### DIFF
--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -521,7 +521,7 @@ class Settings extends Page implements HasForms
                             ->label(trans('admin/setting.oauth.enable'))
                             ->color('success')
                             ->steps($oauthProvider->getSetupSteps())
-                            ->modalHeading(trans('admin/setting.oauth.enable') . $name)
+                            ->modalHeading(trans('admin/setting.oauth.enable') . ' ' . $name)
                             ->modalSubmitActionLabel(trans('admin/setting.oauth.enable'))
                             ->modalCancelAction(false)
                             ->action(function ($data, Set $set) use ($id) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97493060-2107-40a1-90d3-de22146f645c)
![image](https://github.com/user-attachments/assets/a4171fff-2dc8-4d60-b56f-75ad198b85b6)
