### PR TITLE
Fix `FindViableNodeService` to actually filter `Tags`

### DIFF
--- a/app/Services/Deployment/FindViableNodesService.php
+++ b/app/Services/Deployment/FindViableNodesService.php
@@ -29,7 +29,7 @@ class FindViableNodesService
             ->get();
 
         return $nodes
-            ->filter(fn (Node $node) => !tags || collect($node->tags)->intersect($tags)->isNotEmpty())
+            ->filter(fn (Node $node) => !$tags || collect($node->tags)->intersect($tags)->isNotEmpty())
             ->filter(fn (Node $node) => $node->isViable($memory, $disk, $cpu));
     }
 }

--- a/app/Services/Deployment/FindViableNodesService.php
+++ b/app/Services/Deployment/FindViableNodesService.php
@@ -29,7 +29,7 @@ class FindViableNodesService
             ->get();
 
         return $nodes
-            ->filter(fn (Node $node) => !$tags || !collect($node->tags)->intersect($tags)->isEmpty())
+            ->filter(fn (Node $node) => collect($node->tags)->intersect($tags)->isNotEmpty())
             ->filter(fn (Node $node) => $node->isViable($memory, $disk, $cpu));
     }
 }

--- a/app/Services/Deployment/FindViableNodesService.php
+++ b/app/Services/Deployment/FindViableNodesService.php
@@ -29,7 +29,7 @@ class FindViableNodesService
             ->get();
 
         return $nodes
-            ->filter(fn (Node $node) => !$tags || collect($node->tags)->intersect($tags))
+            ->filter(fn (Node $node) => !$tags || !collect($node->tags)->intersect($tags)->isEmpty())
             ->filter(fn (Node $node) => $node->isViable($memory, $disk, $cpu));
     }
 }

--- a/app/Services/Deployment/FindViableNodesService.php
+++ b/app/Services/Deployment/FindViableNodesService.php
@@ -29,7 +29,7 @@ class FindViableNodesService
             ->get();
 
         return $nodes
-            ->filter(fn (Node $node) => collect($node->tags)->intersect($tags)->isNotEmpty())
+            ->filter(fn (Node $node) => !tags || collect($node->tags)->intersect($tags)->isNotEmpty())
             ->filter(fn (Node $node) => $node->isViable($memory, $disk, $cpu));
     }
 }


### PR DESCRIPTION
Hi,

I found out that tags (or locations_id) were ignored in the endpoint `/nodes/deployable`.

This PR fixes the issue by checking if the collection is not empty.