### PR TITLE
Fix `OAuth` `Routes`, function calls need to be public

### DIFF
--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -24,7 +24,7 @@ class OAuthController extends Controller
     /**
      * Redirect user to the OAuth provider
      */
-    protected function redirect(string $driver): RedirectResponse
+    public function redirect(string $driver): RedirectResponse
     {
         // Driver is disabled - redirect to normal login
         if (!OAuthProvider::get($driver)->isEnabled()) {
@@ -37,7 +37,7 @@ class OAuthController extends Controller
     /**
      * Callback from OAuth provider.
      */
-    protected function callback(Request $request, string $driver): RedirectResponse
+    public function callback(Request $request, string $driver): RedirectResponse
     {
         // Driver is disabled - redirect to normal login
         if (!OAuthProvider::get($driver)->isEnabled()) {

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,9 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Auth;
+use App\Http\Controllers\Auth\OAuthController;
 
 Route::redirect('/login', '/login')->name('auth.login');
 
-Route::get('/oauth/redirect/{driver}', [Auth\OAuthController::class, 'redirect'])->name('auth.oauth.redirect');
-Route::get('/oauth/callback/{driver}', [Auth\OAuthController::class, 'callback'])->name('auth.oauth.callback')->withoutMiddleware('guest');
+Route::prefix('oauth')->group(function () {
+    Route::get('/redirect/{driver}', [OAuthController::class, 'redirect'])->name('auth.oauth.redirect');
+    Route::get('/callback/{driver}', [OAuthController::class, 'callback'])->name('auth.oauth.callback')->withoutMiddleware('guest');
+});


### PR DESCRIPTION
The scope now matters as of Laravel 12
> [2025-03-09 18:07:28] production.ERROR: Call to protected method App\Http\Controllers\Auth\OAuthController::redirect() from scope Illuminate\Routing\ControllerDispatcher {"exception":"[object] (Error(code: 0): Call to protected method App\\Http\\Controllers\\Auth\\OAuthController::redirect() from scope Illuminate\\Routing\\ControllerDispatcher at /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php:47)
[stacktrace]