### PR TITLE
Add Authelia OAuth provider

### DIFF
--- a/app/Extensions/OAuth/Providers/AutheliaProvider.php
+++ b/app/Extensions/OAuth/Providers/AutheliaProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Extensions\OAuth\Providers;
+
+use Filament\Forms\Components\ColorPicker;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Foundation\Application;
+use SocialiteProviders\Authelia\Provider;
+
+final class AutheliaProvider extends OAuthProvider
+{
+    public function __construct(protected Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getId(): string
+    {
+        return 'authelia';
+    }
+
+    public function getProviderClass(): string
+    {
+        return Provider::class;
+    }
+
+    public function getServiceConfig(): array
+    {
+        return [
+            'base_url' => env('OAUTH_AUTHELIA_BASE_URL'),
+            'client_id' => env('OAUTH_AUTHELIA_CLIENT_ID'),
+            'client_secret' => env('OAUTH_AUTHELIA_CLIENT_SECRET'),
+        ];
+    }
+
+    public function getSettingsForm(): array
+    {
+        return array_merge(parent::getSettingsForm(), [
+            TextInput::make('OAUTH_AUTHELIA_BASE_URL')
+                ->label('Base URL')
+                ->placeholder('Base URL')
+                ->columnSpan(2)
+                ->required()
+                ->url()
+                ->autocomplete(false)
+                ->default(env('OAUTH_AUTHELIA_BASE_URL')),
+            TextInput::make('OAUTH_AUTHELIA_DISPLAY_NAME')
+                ->label('Display Name')
+                ->placeholder('Display Name')
+                ->autocomplete(false)
+                ->default(env('OAUTH_AUTHELIA_DISPLAY_NAME', 'Authelia')),
+            ColorPicker::make('OAUTH_AUTHELIA_DISPLAY_COLOR')
+                ->label('Display Color')
+                ->placeholder('#b2c6fe')
+                ->default(env('OAUTH_AUTHELIA_DISPLAY_COLOR', '#b2c6fe'))
+                ->hex(),
+        ]);
+    }
+
+    public function getName(): string
+    {
+        return env('OAUTH_AUTHELIA_DISPLAY_NAME', 'Authelia');
+    }
+
+    public function getHexColor(): string
+    {
+        return env('OAUTH_AUTHELIA_DISPLAY_COLOR', '#b2c6fe');
+    }
+
+    public static function register(Application $app): self
+    {
+        return new self($app);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,6 +38,7 @@ use App\Checks\DatabaseCheck;
 use App\Checks\DebugModeCheck;
 use App\Checks\EnvironmentCheck;
 use App\Checks\ScheduleCheck;
+use App\Extensions\OAuth\Providers\AutheliaProvider;
 use Spatie\Health\Facades\Health;
 
 class AppServiceProvider extends ServiceProvider
@@ -104,6 +105,7 @@ class AppServiceProvider extends ServiceProvider
         CommonProvider::register($app, 'slack', null, 'tabler-brand-slack', '#6ecadc');
 
         // Additional OAuth providers from socialiteproviders.com
+        AutheliaProvider::register($app);
         AuthentikProvider::register($app);
         DiscordProvider::register($app);
         SteamProvider::register($app);

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "predis/predis": "^2.3",
         "s1lentium/iptools": "~1.2.0",
         "secondnetwork/blade-tabler-icons": "^3.26",
+        "socialiteproviders/authelia": "^4.0",
         "socialiteproviders/authentik": "^5.2",
         "socialiteproviders/discord": "^4.2",
         "socialiteproviders/steam": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca33e335f355dd9ee36360f7672ac9fc",
+    "content-hash": "fa9e3cf34f31cd13ef3c342b1ba25a31",
     "packages": [
         {
             "name": "abdelhamiderrahmouni/filament-monaco-editor",
@@ -8132,6 +8132,56 @@
             "time": "2025-02-19T10:36:52+00:00"
         },
         {
+            "name": "socialiteproviders/authelia",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SocialiteProviders/Authelia.git",
+                "reference": "6086d52a4471a4d29cd2eb03916e67af780d3ee3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SocialiteProviders/Authelia/zipball/6086d52a4471a4d29cd2eb03916e67af780d3ee3",
+                "reference": "6086d52a4471a4d29cd2eb03916e67af780d3ee3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.2",
+                "socialiteproviders/manager": "^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\Authelia\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "yajtpg",
+                    "email": "yajtpg@gmail.com"
+                }
+            ],
+            "description": "Authelia OAuth2 Provider for Laravel Socialite",
+            "keywords": [
+                "authelia",
+                "laravel",
+                "oauth",
+                "provider",
+                "socialite"
+            ],
+            "support": {
+                "docs": "https://socialiteproviders.com/authentik",
+                "issues": "https://github.com/socialiteproviders/providers/issues",
+                "source": "https://github.com/socialiteproviders/providers"
+            },
+            "time": "2025-02-02T20:59:01+00:00"
+        },
+        {
             "name": "socialiteproviders/authentik",
             "version": "5.2.0",
             "source": {
@@ -15955,7 +16005,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -15966,6 +16016,6 @@
         "ext-pdo": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This PR simply add a Oauth provider for Authelia.

Tested in docker with my personal Authelia.

Here my id provider config in authelia used to test this:

```yml
client_id: pelican
client_name: Pelican
client_secret: "xxxxxxxxxxx"
public: false
authorization_policy: two_factor
redirect_uris:
  - "https://localhost/auth/oauth/callback/authelia"
pre_configured_consent_duration: "1y"
scopes:
  - openid
  - profile
  - email
  - groups
token_endpoint_auth_method: "client_secret_post"
```