### PR TITLE
Add App Logo

### DIFF
--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -117,12 +117,24 @@ class Settings extends Page implements HasForms
                 ->label(trans('admin/setting.general.app_name'))
                 ->required()
                 ->default(env('APP_NAME', 'Pelican')),
-            TextInput::make('APP_FAVICON')
-                ->label(trans('admin/setting.general.app_favicon'))
-                ->hintIcon('tabler-question-mark')
-                ->hintIconTooltip(trans('admin/setting.general.app_favicon_help'))
-                ->required()
-                ->default(env('APP_FAVICON', '/pelican.ico')),
+            Group::make()
+                ->columns(2)
+                ->schema([
+                    TextInput::make('APP_LOGO')
+                        ->label(trans('admin/setting.general.app_logo'))
+                        ->hintIcon('tabler-question-mark')
+                        ->hintIconTooltip(trans('admin/setting.general.app_logo_help'))
+                        ->required()
+                        ->default(env('APP_LOGO', '/pelican.svg'))
+                        ->placeholder('/pelican.svg'),
+                    TextInput::make('APP_FAVICON')
+                        ->label(trans('admin/setting.general.app_favicon'))
+                        ->hintIcon('tabler-question-mark')
+                        ->hintIconTooltip(trans('admin/setting.general.app_favicon_help'))
+                        ->required()
+                        ->default(env('APP_FAVICON', '/pelican.ico'))
+                        ->placeholder('/pelican.ico'),
+                ]),
             Toggle::make('APP_DEBUG')
                 ->label(trans('admin/setting.general.debug_mode'))
                 ->inline(false)

--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -124,8 +124,7 @@ class Settings extends Page implements HasForms
                         ->label(trans('admin/setting.general.app_logo'))
                         ->hintIcon('tabler-question-mark')
                         ->hintIconTooltip(trans('admin/setting.general.app_logo_help'))
-                        ->required()
-                        ->default(env('APP_LOGO', '/pelican.svg'))
+                        ->default(env('APP_LOGO'))
                         ->placeholder('/pelican.svg'),
                     TextInput::make('APP_FAVICON')
                         ->label(trans('admin/setting.general.app_favicon'))

--- a/config/app.php
+++ b/config/app.php
@@ -3,7 +3,7 @@
 return [
 
     'name' => env('APP_NAME', 'Pelican'),
-    'logo' => env('APP_LOGO', '/pelican.svg'),
+    'logo' => env('APP_LOGO'),
     'favicon' => env('APP_FAVICON', '/pelican.ico'),
 
     'version' => 'canary',

--- a/lang/en/admin/setting.php
+++ b/lang/en/admin/setting.php
@@ -14,6 +14,8 @@ return [
     ],
     'general' => [
         'app_name' => 'App Name',
+        'app_logo' => 'App Logo',
+        'app_logo_help' => 'Logo should be placed in the public folder, located in the root panel directory.',
         'app_favicon' => 'App Favicon',
         'app_favicon_help' => 'Favicons should be placed in the public folder, located in the root panel directory.',
         'debug_mode' => 'Debug Mode',

--- a/lang/en/admin/setting.php
+++ b/lang/en/admin/setting.php
@@ -15,9 +15,9 @@ return [
     'general' => [
         'app_name' => 'App Name',
         'app_logo' => 'App Logo',
-        'app_logo_help' => 'Logo should be placed in the public folder, located in the root panel directory.',
+        'app_logo_help' => 'Logo should be placed in the public folder located in the root panel directory. Leave blank to use App Name instead.',
         'app_favicon' => 'App Favicon',
-        'app_favicon_help' => 'Favicons should be placed in the public folder, located in the root panel directory.',
+        'app_favicon_help' => 'Favicon should be placed in the public folder located in the root panel directory.',
         'debug_mode' => 'Debug Mode',
         'navigation' => 'Navigation',
         'sidebar' => 'Sidebar',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ad72e208-e9bf-47e2-8798-aa7cd2694a4e)
![image](https://github.com/user-attachments/assets/fb6ec15b-307d-4575-8930-e0c1981460ec)
![image](https://github.com/user-attachments/assets/199bb620-46e5-4f31-b050-d90e83199bde)
![image](https://github.com/user-attachments/assets/b896ec5e-b248-45f5-8da6-cbe783bcf7bf)
![image](https://github.com/user-attachments/assets/274d4e09-6399-4bf3-a67e-ed98c40cdbc8)

I didn't want to flood but Auth logo works the same way nav does, if the logo is null its gonna print app.name and if its invalid it will print `Pelican logo` (app.name + 'logo')