### PR TITLE
Fix path resolving when moving files

### DIFF
--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -198,16 +198,19 @@ class ListFiles extends ListRecords
                             $this->getDaemonFileRepository()
                                 ->renameFiles($this->path, $files);
 
+                            $oldLocation = join_paths($this->path, $file->name);
+                            $newLocation = resolve_path(join_paths($this->path, $data['location']));
+
                             Activity::event('server:file.rename')
                                 ->property('directory', $this->path)
                                 ->property('files', $files)
-                                ->property('to', $data['location'])
-                                ->property('from', $file->name)
+                                ->property('to', $newLocation)
+                                ->property('from', $oldLocation)
                                 ->log();
 
                             Notification::make()
                                 ->title('File Moved')
-                                ->body(join_paths($this->path, $file->name) . ' -> ' . resolve_path(join_paths($this->path, $data['location'])))
+                                ->body($oldLocation . ' -> ' . $newLocation)
                                 ->success()
                                 ->send();
                         }),

--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -184,22 +184,22 @@ class ListFiles extends ListRecords
                         ->icon('tabler-replace')
                         ->form([
                             TextInput::make('location')
-                                ->label('File name')
-                                ->hint('Enter the new name and directory of this file or folder, relative to the current directory.')
-                                ->default(fn (File $file) => $file->name)
+                                ->label('New location')
+                                ->hint('Enter the location of this file or folder, relative to the current directory.')
                                 ->required()
                                 ->live(),
                             Placeholder::make('new_location')
-                                ->content(fn (Get $get) => resolve_path('./' . join_paths($this->path, $get('location')))),
+                                ->content(fn (Get $get, File $file) => resolve_path('./' . join_paths($this->path, $get('location') ?? '/', $file->name))),
                         ])
                         ->action(function ($data, File $file) {
-                            $files = [['to' => $data['location'], 'from' => $file->name]];
+                            $location = rtrim($data['location'], '/');
+                            $files = [['to' => join_paths($location, $file->name), 'from' => $file->name]];
 
                             $this->getDaemonFileRepository()
                                 ->renameFiles($this->path, $files);
 
                             $oldLocation = join_paths($this->path, $file->name);
-                            $newLocation = resolve_path(join_paths($this->path, $data['location']));
+                            $newLocation = resolve_path(join_paths($this->path, $location, $file->name));
 
                             Activity::event('server:file.rename')
                                 ->property('directory', $this->path)

--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -193,9 +193,7 @@ class ListFiles extends ListRecords
                                 ->content(fn (Get $get) => resolve_path('./' . join_paths($this->path, $get('location')))),
                         ])
                         ->action(function ($data, File $file) {
-                            $location = resolve_path(join_paths($this->path, $data['location']));
-
-                            $files = [['to' => $location, 'from' => $file->name]];
+                            $files = [['to' => $data['location'], 'from' => $file->name]];
 
                             $this->getDaemonFileRepository()
                                 ->renameFiles($this->path, $files);
@@ -203,12 +201,13 @@ class ListFiles extends ListRecords
                             Activity::event('server:file.rename')
                                 ->property('directory', $this->path)
                                 ->property('files', $files)
-                                ->property('to', $location)
+                                ->property('to', $data['location'])
                                 ->property('from', $file->name)
                                 ->log();
 
                             Notification::make()
-                                ->title(join_paths($this->path, $file->name) . ' was moved to ' . $location)
+                                ->title('File Moved')
+                                ->body(join_paths($this->path, $file->name) . ' -> ' . resolve_path(join_paths($this->path, $data['location'])))
                                 ->success()
                                 ->send();
                         }),

--- a/lang/en/activity.php
+++ b/lang/en/activity.php
@@ -74,7 +74,7 @@ return [
             'delete' => 'Deleted <b>:directory:files</b>|Deleted <b>:count</b> files in <b>:directory</b>',
             'download' => 'Downloaded <b>:file</b>',
             'pull' => 'Downloaded a remote file from <b>:url</b> to <b>:directory</b>',
-            'rename' => 'Renamed <b>:directory:from</b> to <b>:directory:to</b>|Renamed <b>:count</b> files in <b>:directory</b>',
+            'rename' => 'Moved/ Renamed <b>:from</b> to <b>:to</b>|Moved/ Renamed <b>:count</b> files in <b>:directory</b>',
             'write' => 'Wrote new content to <b>:file</b>',
             'upload' => 'Began a file upload',
             'uploaded' => 'Uploaded <b>:directory:file</b>',


### PR DESCRIPTION
Wings can handle moving backwards (`../file.txt`) so we don't need to resolve the path on the panel side.