### PR TITLE
Remove unused groupBy

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -289,8 +289,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
             ->leftJoin('subusers', 'subusers.server_id', '=', 'servers.id')
             ->where(function (Builder $builder) {
                 $builder->where('servers.owner_id', $this->id)->orWhere('subusers.user_id', $this->id);
-            })
-            ->groupBy('servers.id');
+            });
     }
 
     public function subusers(): HasMany


### PR DESCRIPTION
Fixes #1107


Left over from old client UI, was always returning 1, which broke server counts on the dashboard 

![image](https://github.com/user-attachments/assets/a964374c-fb62-49df-990b-136c9c79934b)
