### PR TITLE
Catch 500 on backup page when you hit the backup rate limit

### DIFF
--- a/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
@@ -182,15 +182,11 @@ class ListBackups extends ListRecords
                             ->send();
 
                     } catch (HttpException $e) {
-                        $retry = $e->getHeaders()['Retry-After'] ?? 'error';
-                        $message = $e->getMessage() . ' Try again in ' . $retry . ' seconds.';
-
                         return Notification::make()
                             ->danger()
                             ->title('Backup Failed')
-                            ->body($message)
+                            ->body($e->getMessage() . ' Try again' . ($e->getHeaders()['Retry-After'] ? ' in ' . $e->getHeaders()['Retry-After'] . ' seconds.' : ''))
                             ->send();
-
                     }
                 }),
         ];

--- a/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
@@ -31,7 +31,7 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Http\Request;
-use Throwable;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ListBackups extends ListRecords
 {
@@ -181,12 +181,14 @@ class ListBackups extends ListRecords
                             ->success()
                             ->send();
 
-                    } catch (Throwable $e) {
+                    } catch (HttpException $e) {
+                        $retry = $e->getHeaders()['Retry-After'] ?? 'error';
+                        $message = $e->getMessage() . ' Try again in ' . $retry . ' seconds.';
 
                         return Notification::make()
                             ->danger()
                             ->title('Backup Failed')
-                            ->body($e->getMessage() . ' Try again in ' . $e->getheaders()['Retry-After'] . ' seconds.')
+                            ->body($message)
                             ->send();
 
                     }

--- a/app/Services/Backups/InitiateBackupService.php
+++ b/app/Services/Backups/InitiateBackupService.php
@@ -85,7 +85,7 @@ class InitiateBackupService
             if ($previous->count() >= $limit) {
                 $message = sprintf('Only %d backups may be generated within a %d second span of time.', $limit, $period);
 
-                throw new TooManyRequestsHttpException((int) now()->diffInSeconds($previous->last()->created_at->addSeconds($period)), $message);
+                throw new TooManyRequestsHttpException((int) now()->diffInSeconds($previous->last()->created_at->addSeconds((int) $period)), $message);
             }
         }
 


### PR DESCRIPTION
Fix the 500 on backups when you've exceeded the x allowed for x seconds and inform the end user. 
![image](https://github.com/user-attachments/assets/02889be0-27ef-49a4-ba99-499eee6f81a1)
