### PR TITLE
Add `FileNotEditableException`

### DIFF
--- a/app/Exceptions/Repository/FileNotEditableException.php
+++ b/app/Exceptions/Repository/FileNotEditableException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions\Repository;
+
+use Exception;
+
+class FileNotEditableException extends Exception {}

--- a/app/Filament/Server/Resources/FileResource/Pages/EditFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/EditFiles.php
@@ -4,6 +4,7 @@ namespace App\Filament\Server\Resources\FileResource\Pages;
 
 use AbdelhamidErrahmouni\FilamentMonacoEditor\MonacoEditor;
 use App\Enums\EditorLanguages;
+use App\Exceptions\Repository\FileNotEditableException;
 use App\Facades\Activity;
 use App\Filament\Server\Resources\FileResource;
 use App\Livewire\AlertBanner;
@@ -132,6 +133,8 @@ class EditFiles extends Page
                                         ->getContent($this->path, config('panel.files.max_edit_size'));
                                 } catch (FileNotFoundException) {
                                     abort(404, $this->path . ' not found.');
+                                } catch (FileNotEditableException) {
+                                    abort(400, $this->path . ' is not editable.');
                                 }
                             })
                             ->language(fn (Get $get) => $get('lang'))

--- a/app/Repositories/Daemon/DaemonFileRepository.php
+++ b/app/Repositories/Daemon/DaemonFileRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories\Daemon;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\Client\Response;
 use App\Exceptions\Http\Server\FileSizeTooLargeException;
+use App\Exceptions\Repository\FileNotEditableException;
 use Illuminate\Http\Client\ConnectionException;
 
 class DaemonFileRepository extends DaemonRepository
@@ -27,6 +28,10 @@ class DaemonFileRepository extends DaemonRepository
         $length = $response->header('Content-Length');
         if ($notLargerThan && $length > $notLargerThan) {
             throw new FileSizeTooLargeException();
+        }
+
+        if ($response->getStatusCode() === 400) {
+            throw new FileNotEditableException();
         }
 
         if ($response->getStatusCode() === 404) {

--- a/resources/views/errors/400.blade.php
+++ b/resources/views/errors/400.blade.php
@@ -1,0 +1,8 @@
+@props([
+'code' => '400',
+'title' => 'Bad request',
+'subtitle' => $exception->getMessage(),
+'icon' => 'tabler-exclamation-circle'
+])
+
+@extends('errors::layout')


### PR DESCRIPTION
Catch trying to edit a `Directory` like if it was `File` content
https://github.com/pelican-dev/wings/pull/78
![image](https://github.com/user-attachments/assets/4024b29d-3870-4bff-bca3-e4c8d7c05003)
