### PR TITLE
Add host config to gitlab oauth (& add setup steps)

### DIFF
--- a/app/Extensions/OAuth/Providers/GitlabProvider.php
+++ b/app/Extensions/OAuth/Providers/GitlabProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Extensions\OAuth\Providers;
+
+use Filament\Forms\Components\TextInput;
+use Illuminate\Foundation\Application;
+
+final class GitlabProvider extends OAuthProvider
+{
+    public function __construct(protected Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getId(): string
+    {
+        return 'gitlab';
+    }
+
+    public function getServiceConfig(): array
+    {
+        return array_merge(parent::getServiceConfig(), [
+            'host' => env('OAUTH_GITLAB_HOST'),
+        ]);
+    }
+
+    public function getSettingsForm(): array
+    {
+        return array_merge(parent::getSettingsForm(), [
+            TextInput::make('OAUTH_GITLAB_HOST')
+                ->label('Custom Host')
+                ->placeholder('Only set a custom host if you are self hosting gitlab')
+                ->columnSpan(2)
+                ->url()
+                ->autocomplete(false)
+                ->default(env('OAUTH_GITLAB_HOST')),
+        ]);
+    }
+
+    public function getSetupSteps(): array
+    {
+        // TODO
+        return parent::getSetupSteps();
+    }
+
+    public function getIcon(): string
+    {
+        return 'tabler-brand-gitlab';
+    }
+
+    public function getHexColor(): string
+    {
+        return '#fca326';
+    }
+
+    public static function register(Application $app): self
+    {
+        return new self($app);
+    }
+}

--- a/app/Extensions/OAuth/Providers/GitlabProvider.php
+++ b/app/Extensions/OAuth/Providers/GitlabProvider.php
@@ -2,8 +2,14 @@
 
 namespace App\Extensions\OAuth\Providers;
 
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Wizard\Step;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+use Webbingbrasil\FilamentCopyActions\Forms\Actions\CopyAction;
 
 final class GitlabProvider extends OAuthProvider
 {
@@ -39,8 +45,19 @@ final class GitlabProvider extends OAuthProvider
 
     public function getSetupSteps(): array
     {
-        // TODO
-        return parent::getSetupSteps();
+        return array_merge([
+            Step::make('Register new Gitlab OAuth App')
+                ->schema([
+                    Placeholder::make('')
+                        ->content(new HtmlString(Blade::render('Check out the <x-filament::link href="https://docs.gitlab.com/integration/oauth_provider/" target="_blank">Gitlab docs</x-filament::link> on how to create the oauth app.'))),
+                    TextInput::make('_noenv_callback')
+                        ->label('Redirect URI')
+                        ->dehydrated()
+                        ->disabled()
+                        ->hintAction(fn () => request()->isSecure() ? CopyAction::make() : null)
+                        ->default(fn () => config('app.url') . (Str::endsWith(config('app.url'), '/') ? '' : '/') . 'auth/oauth/callback/gitlab'),
+                ]),
+        ], parent::getSetupSteps());
     }
 
     public function getIcon(): string

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Checks\NodeVersionsCheck;
 use App\Checks\PanelVersionCheck;
 use App\Checks\ScheduleCheck;
 use App\Checks\UsedDiskSpaceCheck;
+use App\Extensions\OAuth\Providers\GitlabProvider;
 use App\Models;
 use App\Extensions\Captcha\Providers\TurnstileProvider;
 use App\Extensions\OAuth\Providers\AuthentikProvider;
@@ -97,7 +98,7 @@ class AppServiceProvider extends ServiceProvider
         CommonProvider::register($app, 'linkedin', null, 'tabler-brand-linkedin-f', '#0a66c2');
         CommonProvider::register($app, 'google', null, 'tabler-brand-google-f', '#4285f4');
         GithubProvider::register($app);
-        CommonProvider::register($app, 'gitlab', null, 'tabler-brand-gitlab', '#fca326');
+        GitlabProvider::register($app);
         CommonProvider::register($app, 'bitbucket', null, 'tabler-brand-bitbucket-f', '#205081');
         CommonProvider::register($app, 'slack', null, 'tabler-brand-slack', '#6ecadc');
 


### PR DESCRIPTION
Allows to set a custom host if you are self hosting gitlab.

![grafik](https://github.com/user-attachments/assets/42bbdb6d-a537-4612-9d78-5cee24c7e42e)
![grafik](https://github.com/user-attachments/assets/ed2ba752-4f0d-4add-90a1-69d08bfe9bc5)