### PR TITLE
Remove cursor not allowed rule

### DIFF
--- a/public/css/filament/server/console.css
+++ b/public/css/filament/server/console.css
@@ -14,6 +14,10 @@
     padding-right: 10px;
 }
 
+#sendCommand:read-only {
+    cursor: not-allowed;
+}
+
 ::-webkit-scrollbar {
     background: none;
     width: 14px;

--- a/public/css/filament/server/console.css
+++ b/public/css/filament/server/console.css
@@ -14,10 +14,6 @@
     padding-right: 10px;
 }
 
-input:read-only {
-    cursor: not-allowed;
-}
-
 ::-webkit-scrollbar {
     background: none;
     width: 14px;

--- a/public/css/filament/server/console.css
+++ b/public/css/filament/server/console.css
@@ -14,7 +14,7 @@
     padding-right: 10px;
 }
 
-#sendCommand:read-only {
+#send-command:read-only {
     cursor: not-allowed;
 }
 

--- a/resources/views/filament/components/server-console.blade.php
+++ b/resources/views/filament/components/server-console.blade.php
@@ -18,6 +18,7 @@
                 icon="tabler-chevrons-right"
             />
             <input
+                id="sendCommand"
                 class="w-full focus:outline-none focus:ring-0 border-none dark:bg-gray-900"
                 type="text"
                 :readonly="{{ $this->canSendCommand() ? 'false' : 'true' }}"

--- a/resources/views/filament/components/server-console.blade.php
+++ b/resources/views/filament/components/server-console.blade.php
@@ -18,7 +18,7 @@
                 icon="tabler-chevrons-right"
             />
             <input
-                id="sendCommand"
+                id="send-command"
                 class="w-full focus:outline-none focus:ring-0 border-none dark:bg-gray-900"
                 type="text"
                 :readonly="{{ $this->canSendCommand() ? 'false' : 'true' }}"


### PR DESCRIPTION
In the UI for the permissions (role creation and user invitation) all the checkbox have the:
`cursor: not-allowed;`
rule applied even though it is interactable. It tried to create roles and the seems to be purly visual.

I don't know if this is referenced/used by other elements but since I could not find any other usages I think it can be removed