### PR TITLE
Fix activity log on rename api endpoint

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -172,8 +172,8 @@ class FileController extends ClientApiController
         Activity::event('server:file.rename')
             ->property('directory', $request->input('root'))
             ->property('files', $files)
-            ->property('to', $files['to'])
-            ->property('from', $files['from'])
+            ->property('to', $files[0]['to'])
+            ->property('from', $files[0]['from'])
             ->log();
 
         return new JsonResponse([], Response::HTTP_NO_CONTENT);


### PR DESCRIPTION
Closes #1148

`$files` is a two dimensional array because you can rename/ move multiple files at once.
`to` and `from` are only displayed in the activity log if you rename/ move one file so it's fine always using the first item.