### PR TITLE
add a all in one docker compose with example.env and README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,105 @@
+
+# Pelican Panel - Docker Image
+
+## Requirements
+
+- Make sure Docker is installed on your system. You can follow the official Docker installation guide here: [Docker Installation](https://docs.docker.com/engine/install/).
+
+## Setup
+
+1. Create a directory for the Pelican Panel:
+
+```bash
+mkdir -p /opt/pelican-panel
+cd /opt/pelican-panel
+```
+
+2. Download the necessary files (docker-compose.yml and example.env):
+
+```bash
+curl -L -o docker-compose.yml https://raw.githubusercontent.com/pelican-dev/panel/refs/heads/main/docker/docker-compose.yml
+curl -L -o .env https://raw.githubusercontent.com/pelican-dev/panel/refs/heads/main/docker/example.env
+```
+
+3. Edit the `.env` file to adjust the required settings:
+
+```bash
+nano .env
+```
+
+4. Start the Docker container:
+
+```bash
+docker compose up -d
+```
+
+5. Create the first user for the panel:
+
+```bash
+docker compose exec panel php artisan p:user:make
+```
+
+## Debugging
+
+To view the container logs, first navigate to the directory where the Docker Compose file is located:
+
+```bash
+cd /opt/pelican-panel
+```
+
+Then, you can view the logs in real-time using the following command:
+
+```bash
+docker compose logs -f
+```
+
+## Environment Variables
+
+There are several environment variables that you can configure for the panel. You can either provide your own `.env` file or modify the default one. Below is a table of the available options:
+
+**Note:** If your `APP_URL` uses `https://`, you will need to provide an `LE_EMAIL` for Let's Encrypt certificate generation.
+
+| Variable          | Description                                                                   | Required |
+|-------------------|-------------------------------------------------------------------------------|----------|
+| `APP_URL`         | The URL where the panel will be accessible (including protocol)               | Yes      |
+| `APP_TIMEZONE`    | The timezone to use for the panel                                             | Yes      |
+| `LE_EMAIL`        | The email used for Let's Encrypt certificate generation                       | Yes      |
+| `DB_HOST`         | The host of the MySQL instance                                                | Yes      |
+| `DB_PORT`         | The port of the MySQL instance                                                | Yes      |
+| `DB_DATABASE`     | The name of the MySQL database                                                | Yes      |
+| `DB_USERNAME`     | The MySQL user                                                                | Yes      |
+| `DB_PASSWORD`     | The password for the specified MySQL user                                     | Yes      |
+| `CACHE_STORE`     | The cache driver (see [Cache Drivers](#cache-drivers) for details)            | Yes      |
+| `SESSION_DRIVER`  | The session driver to use (refer to Laravel documentation for details)        | Yes      |
+| `QUEUE_DRIVER`    | The queue driver to use (refer to Laravel documentation for details)          | Yes      |
+| `REDIS_HOST`      | The hostname or IP address of the Redis database                              | Yes      |
+| `REDIS_PASSWORD`  | The password for securing the Redis database                                  | Optional |
+| `REDIS_PORT`      | The port the Redis database is using on the host                              | Optional |
+| `MAIL_DRIVER`     | The email driver to use (see [Mail Drivers](#mail-drivers) for details)       | Yes      |
+| `MAIL_FROM`       | The email address used as the sender email                                    | Yes      |
+| `MAIL_HOST`       | The host of your mail driver instance                                         | Optional |
+| `MAIL_PORT`       | The port of your mail driver instance                                         | Optional |
+| `MAIL_USERNAME`   | The username for your mail driver                                             | Optional |
+| `MAIL_PASSWORD`   | The password for your mail driver                                             | Optional |
+
+### Cache Drivers
+
+You can choose from various cache drivers, depending on your preference. If you're using Docker, we recommend Redis as it can be easily run in a container.
+
+| Driver   | Description                          | Required Variables                                 |
+|----------|--------------------------------------|----------------------------------------------------|
+| `redis`  | Host where Redis is running          | `REDIS_HOST`                                       |
+| `redis`  | Port Redis is running on             | `REDIS_PORT`                                       |
+| `redis`  | Redis database password              | `REDIS_PASSWORD`                                   |
+
+### Mail Drivers
+
+Choose a mail driver based on your needs. Below are the available options:
+
+| Driver     | Description                          | Required Variables                                                        |
+|------------|--------------------------------------|---------------------------------------------------------------------------|
+| `mail`     | Uses the built-in PHP mail function  | `MAIL_FROM`                                                               |
+| `mandrill` | [Mandrill](http://www.mandrill.com/) | `MAIL_FROM`, `MAIL_USERNAME`                                              |
+| `postmark` | [Postmark](https://postmarkapp.com/) | `MAIL_FROM`, `MAIL_USERNAME`                                              |
+| `mailgun`  | [Mailgun](https://www.mailgun.com/)  | `MAIL_FROM`, `MAIL_USERNAME`, `MAIL_HOST`                                 |
+| `smtp`     | Any SMTP server configuration        | `MAIL_FROM`, `MAIL_USERNAME`, `MAIL_HOST`, `MAIL_PASSWORD`, `MAIL_PORT`   |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,43 @@
+---
+services:
+  panel:
+    image: ghcr.io/pelican-dev/panel:latest
+    restart: always
+    user: "${UID:?}:${GID:?}"
+    env_file:
+      - .env
+    ports:
+      - "${HTTP_PORT:?}:80"
+      - "${HTTPS_PORT:?}:443"
+      # enable when not using caddy to be able to reach php-fpm
+      # - "9000:9000"
+    volumes:
+      - ./pelican-data:/pelican-data
+      - ./pelican-logs:/var/www/html/storage/logs
+    environment:
+      XDG_DATA_HOME: /pelican-data
+    depends_on:
+      - mariadb
+      - redis
+
+
+  mariadb:
+    image: mariadb:latest
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?}
+      MYSQL_DATABASE: ${DB_DATABASE:?}
+      MYSQL_USER: ${DB_USERNAME:?}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?}
+    volumes:
+      - ./mariadb:/var/lib/mysql
+
+
+  redis:
+    image: redis:latest
+    restart: always
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD:?}"]
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?}
+    volumes:
+      - ./redis:/data

--- a/docker/example.env
+++ b/docker/example.env
@@ -1,0 +1,47 @@
+# General Settings
+APP_URL=http://<domain or IPAddress>
+APP_TIMEZONE=Europe/Berlin
+APP_DEBUG=false
+APP_ENV=production
+APP_LOCALE=en
+
+# Let's Encrypt Settings (optional)
+# Note: If APP_URL starts with "https://", you need to provide LE_EMAIL for certificates to be generated
+# LE_EMAIL=your-email@example.com
+
+# Web Port for the Panel
+HTTP_PORT=80
+HTTPS_PORT=443
+
+# UID and GID for the pelican container
+UID=0
+GID=0
+
+# Caddy Settings
+ADMIN_EMAIL=pelican@example.com
+
+# Database Settings
+DB_HOST=mariadb
+DB_PORT=3306
+DB_DATABASE=pelican-panel
+DB_USERNAME=pelican-user
+DB_PASSWORD=change_me_please
+DB_ROOT_PASSWORD=change_me_please
+
+# Redis Settings
+CACHE_STORE=redis
+SESSION_DRIVER=redis
+QUEUE_DRIVER=redis
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=change_me_please
+
+# Mail Settings
+# Options: log, mail, mandrill, postmark, mailgun, smtp
+# For more info see the documentation
+MAIL_DRIVER=log
+# MAIL_FROM=noreply@yourdomain.com
+# MAIL_HOST=smtp.yourprovider.com
+# MAIL_PORT=587
+# MAIL_USERNAME=your-email@example.com
+# MAIL_PASSWORD=your-email-password


### PR DESCRIPTION
Hello everyone,
This PR introduces an all-in-one `docker-compose.yml` that directly includes the `database` and `Redis`. Additionally, there is a `.env` file where all settings can be configured.

The docker/README.md explains how to install the panel using docker-compose and the .env file.