### PR TITLE
Must use `Closure` since `MenuItem` does not leverage Concerns

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -40,9 +40,11 @@ class AdminPanelProvider extends PanelProvider
             ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
             ->login(Login::class)
             ->userMenuItems([
-                'profile' => MenuItem::make()->label(trans('filament-panels::pages.auth.edit-profile.label'))->url(fn () => EditProfile::getUrl(panel: 'app')),
+                'profile' => MenuItem::make()
+                    ->label(fn () => trans('filament-panels::pages/auth/edit-profile.label'))
+                    ->url(fn () => EditProfile::getUrl(panel: 'app')),
                 MenuItem::make()
-                    ->label(trans('profile.exit_admin'))
+                    ->label(fn () => trans('profile.exit_admin'))
                     ->url('/')
                     ->icon('tabler-arrow-back')
                     ->sort(24),

--- a/app/Providers/Filament/ServerPanelProvider.php
+++ b/app/Providers/Filament/ServerPanelProvider.php
@@ -43,7 +43,9 @@ class ServerPanelProvider extends PanelProvider
             ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
             ->login(Login::class)
             ->userMenuItems([
-                'profile' => MenuItem::make()->label('Profile')->url(fn () => EditProfile::getUrl(panel: 'app')),
+                'profile' => MenuItem::make()
+                    ->label('Profile')
+                    ->url(fn () => EditProfile::getUrl(panel: 'app')),
                 MenuItem::make()
                     ->label('Server List')
                     ->icon('tabler-brand-docker')

--- a/app/Providers/Filament/ServerPanelProvider.php
+++ b/app/Providers/Filament/ServerPanelProvider.php
@@ -44,7 +44,7 @@ class ServerPanelProvider extends PanelProvider
             ->login(Login::class)
             ->userMenuItems([
                 'profile' => MenuItem::make()
-                    ->label('Profile')
+                    ->label(fn () => trans('filament-panels::pages/auth/edit-profile.label'))
                     ->url(fn () => EditProfile::getUrl(panel: 'app')),
                 MenuItem::make()
                     ->label('Server List')


### PR DESCRIPTION
https://github.com/filamentphp/filament/issues/13342
I hate cache it should have been catched before https://github.com/pelican-dev/panel/pull/1178