### PR TITLE
Fix typo for `SESSION_DRIVER` in `RedisSetupCommand`

### DIFF
--- a/app/Console/Commands/Environment/RedisSetupCommand.php
+++ b/app/Console/Commands/Environment/RedisSetupCommand.php
@@ -35,7 +35,7 @@ class RedisSetupCommand extends Command
     {
         $this->variables['CACHE_STORE'] = 'redis';
         $this->variables['QUEUE_CONNECTION'] = 'redis';
-        $this->variables['SESSION_DRIVERS'] = 'redis';
+        $this->variables['SESSION_DRIVER'] = 'redis';
 
         $this->requestRedisSettings();
 


### PR DESCRIPTION
`php artisan p:redis:setup` didn't ever change SESSION_DRIVER

![image](https://github.com/user-attachments/assets/bf362fbf-85f6-4dd8-9cde-ec93ade7abc3)
![image](https://github.com/user-attachments/assets/71141405-722f-4a8d-8c32-f31fad4d2dd5)
![image](https://github.com/user-attachments/assets/cef2c6a5-c52e-4864-a2aa-52d8d4d40dd2) ![image](https://github.com/user-attachments/assets/779d884c-0849-4211-adb7-8f361706dfe3)
