### PR TITLE
Add unique `foreign keys` for `EggVariable`

### DIFF
--- a/database/migrations/2025_04_01_033956_egg_variable_unique_foreign_key.php
+++ b/database/migrations/2025_04_01_033956_egg_variable_unique_foreign_key.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('egg_variables', function (Blueprint $table) {
+            $table->unique(['egg_id', 'env_variable']);
+            $table->unique(['egg_id', 'name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('egg_variables', function (Blueprint $table) {
+            $table->dropUnique(['egg_id', 'env_variable']);
+            $table->dropUnique(['egg_id', 'name']);
+        });
+    }
+};

--- a/tests/Integration/Api/Client/Server/Startup/GetStartupAndVariablesTest.php
+++ b/tests/Integration/Api/Client/Server/Startup/GetStartupAndVariablesTest.php
@@ -23,7 +23,7 @@ class GetStartupAndVariablesTest extends ClientApiIntegrationTestCase
         $egg = $this->cloneEggAndVariables($server->egg);
         // BUNGEE_VERSION should never be returned to the user in this API call, either in
         // the array of variables, or revealed in the startup command.
-        $egg->variables()->first()->update([
+        $egg->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->update([
             'user_viewable' => false,
         ]);
 

--- a/tests/Integration/Api/Client/Server/Startup/UpdateStartupVariableTest.php
+++ b/tests/Integration/Api/Client/Server/Startup/UpdateStartupVariableTest.php
@@ -39,7 +39,7 @@ class UpdateStartupVariableTest extends ClientApiIntegrationTestCase
 
         $response->assertOk();
         $response->assertJsonPath('object', EggVariable::RESOURCE_NAME);
-        $this->assertJsonTransformedWith($response->json('attributes'), $server->variables[0]);
+        $this->assertJsonTransformedWith($response->json('attributes'), $server->variables->firstWhere('env_variable', 'BUNGEE_VERSION'));
         $response->assertJsonPath('meta.startup_command', 'java bungeecord.jar --version 123');
         $response->assertJsonPath('meta.raw_startup_command', $server->startup);
     }
@@ -90,7 +90,7 @@ class UpdateStartupVariableTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount();
 
         $egg = $this->cloneEggAndVariables($server->egg);
-        $egg->variables()->first()->update(['user_viewable' => false]);
+        $egg->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->update(['user_viewable' => false]);
 
         $server->fill([
             'egg_id' => $egg->id,
@@ -119,7 +119,7 @@ class UpdateStartupVariableTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount();
 
         $egg = $this->cloneEggAndVariables($server->egg);
-        $egg->variables()->first()->update(['rules' => ['nullable', 'string']]);
+        $egg->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->update(['rules' => ['nullable', 'string']]);
 
         $server->fill(['egg_id' => $egg->id])->save();
         $server->refresh();

--- a/tests/Integration/Services/Servers/ServerCreationServiceTest.php
+++ b/tests/Integration/Services/Servers/ServerCreationServiceTest.php
@@ -118,8 +118,8 @@ class ServerCreationServiceTest extends IntegrationTestCase
         $this->assertSame($response->uuid_short, substr($response->uuid, 0, 8));
         $this->assertSame($egg->id, $response->egg_id);
         $this->assertCount(2, $response->variables);
-        $this->assertSame('123', $response->variables()->firstWhere(['env_variable' => 'BUNGEE_VERSION'])->server_value);
-        $this->assertSame('server2.jar', $response->variables()->firstWhere(['env_variable' => 'SERVER_JARFILE'])->server_value);
+        $this->assertSame('123', $response->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->server_value);
+        $this->assertSame('server2.jar', $response->variables()->firstWhere('env_variable', 'SERVER_JARFILE')->server_value);
 
         foreach ($data as $key => $value) {
             if (in_array($key, ['allocation_additional', 'environment', 'start_on_completion'])) {

--- a/tests/Integration/Services/Servers/StartupModificationServiceTest.php
+++ b/tests/Integration/Services/Servers/StartupModificationServiceTest.php
@@ -60,8 +60,8 @@ class StartupModificationServiceTest extends IntegrationTestCase
         $this->assertInstanceOf(Server::class, $result);
         $this->assertCount(2, $result->variables);
         $this->assertSame($server->startup, $result->startup);
-        $this->assertSame('1234', $result->variables[0]->server_value);
-        $this->assertSame('test.jar', $result->variables[1]->server_value);
+        $this->assertSame('1234', $result->variables->firstWhere('env_variable', 'BUNGEE_VERSION')->server_value);
+        $this->assertSame('test.jar', $result->variables->firstWhere('env_variable', 'SERVER_JARFILE')->server_value);
     }
 
     /**
@@ -106,7 +106,7 @@ class StartupModificationServiceTest extends IntegrationTestCase
 
         $clone = $this->cloneEggAndVariables($server->egg);
         // This makes the BUNGEE_VERSION variable not user editable.
-        $clone->variables()->firstWhere(['env_variable' => 'BUNGEE_VERSION'])->update([
+        $clone->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->update([
             'user_editable' => false,
         ]);
 
@@ -115,7 +115,7 @@ class StartupModificationServiceTest extends IntegrationTestCase
 
         ServerVariable::query()->updateOrCreate([
             'server_id' => $server->id,
-            'variable_id' => $server->variables()->firstWhere(['env_variable' => 'BUNGEE_VERSION'])->id,
+            'variable_id' => $server->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->id,
         ], ['variable_value' => 'EXIST']);
 
         $response = $this->getService()->handle($server, [
@@ -126,8 +126,8 @@ class StartupModificationServiceTest extends IntegrationTestCase
         ]);
 
         $this->assertCount(2, $response->variables);
-        $this->assertSame('EXIST', $response->variables()->firstWhere(['env_variable' => 'BUNGEE_VERSION'])->server_value);
-        $this->assertSame('test.jar', $response->variables()->firstWhere(['env_variable' => 'SERVER_JARFILE'])->server_value);
+        $this->assertSame('EXIST', $response->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->server_value);
+        $this->assertSame('test.jar', $response->variables()->firstWhere('env_variable', 'SERVER_JARFILE')->server_value);
 
         $response = $this->getService()
             ->setUserLevel(User::USER_LEVEL_ADMIN)
@@ -139,8 +139,8 @@ class StartupModificationServiceTest extends IntegrationTestCase
             ]);
 
         $this->assertCount(2, $response->variables);
-        $this->assertSame('1234', $response->variables()->firstWhere(['env_variable' => 'BUNGEE_VERSION'])->server_value);
-        $this->assertSame('test.jar', $response->variables()->firstWhere(['env_variable' => 'SERVER_JARFILE'])->server_value);
+        $this->assertSame('1234', $response->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->server_value);
+        $this->assertSame('test.jar', $response->variables()->firstWhere('env_variable', 'SERVER_JARFILE')->server_value);
     }
 
     /**

--- a/tests/Integration/Services/Servers/VariableValidatorServiceTest.php
+++ b/tests/Integration/Services/Servers/VariableValidatorServiceTest.php
@@ -52,12 +52,15 @@ class VariableValidatorServiceTest extends IntegrationTestCase
             'SERVER_JARFILE' => 'server.jar',
         ]);
 
+        $bungeeVersion = $response->firstWhere('key', 'BUNGEE_VERSION');
+        $serverJarfile = $response->firstWhere('key', 'SERVER_JARFILE');
+
         $this->assertInstanceOf(Collection::class, $response);
         $this->assertCount(2, $response);
-        $this->assertSame('BUNGEE_VERSION', $response->get(0)->key);
-        $this->assertSame('1234', $response->get(0)->value);
-        $this->assertSame('SERVER_JARFILE', $response->get(1)->key);
-        $this->assertSame('server.jar', $response->get(1)->value);
+        $this->assertSame('BUNGEE_VERSION', $bungeeVersion->key);
+        $this->assertSame('1234', $bungeeVersion->value);
+        $this->assertSame('SERVER_JARFILE', $serverJarfile->key);
+        $this->assertSame('server.jar', $serverJarfile->value);
     }
 
     /**
@@ -67,7 +70,7 @@ class VariableValidatorServiceTest extends IntegrationTestCase
     public function test_normal_user_cannot_validate_non_user_editable_variables(): void
     {
         $egg = $this->cloneEggAndVariables($this->egg);
-        $egg->variables()->first()->update([
+        $egg->variables()->firstWhere('env_variable', 'BUNGEE_VERSION')->update([
             'user_editable' => false,
         ]);
 
@@ -79,8 +82,8 @@ class VariableValidatorServiceTest extends IntegrationTestCase
 
         $this->assertInstanceOf(Collection::class, $response);
         $this->assertCount(1, $response);
-        $this->assertSame('SERVER_JARFILE', $response->get(0)->key);
-        $this->assertSame('server.jar', $response->get(0)->value);
+        $this->assertSame('SERVER_JARFILE', $response->firstWhere('key', 'SERVER_JARFILE')->key);
+        $this->assertSame('server.jar', $response->firstWhere('key', 'SERVER_JARFILE')->value);
     }
 
     public function test_environment_variables_can_be_updated_as_admin(): void


### PR DESCRIPTION
Supersedes https://github.com/pelican-dev/panel/pull/549
Closes #545 (api side since https://github.com/pelican-dev/panel/pull/902 already makes them unique in the frontend)