### PR TITLE
Fixed filament search bar on edit files language dropdown

### DIFF
--- a/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
@@ -243,6 +243,7 @@ class CreateEgg extends CreateRecord
                                 ->default('ghcr.io/pelican-eggs/installers:debian'),
                             Select::make('script_entry')
                                 ->label(trans('admin/egg.script_entry'))
+                                ->native(false)
                                 ->selectablePlaceholder(false)
                                 ->default('bash')
                                 ->options(['bash', 'ash', '/bin/bash'])

--- a/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
@@ -235,6 +235,7 @@ class EditEgg extends EditRecord
                                 ->placeholder('ghcr.io/pelican-eggs/installers:debian'),
                             Select::make('script_entry')
                                 ->label(trans('admin/egg.script_entry'))
+                                ->native(false)
                                 ->selectablePlaceholder(false)
                                 ->options(['bash', 'ash', '/bin/bash'])
                                 ->required(),

--- a/app/Filament/Components/Forms/Fields/CopyFrom.php
+++ b/app/Filament/Components/Forms/Fields/CopyFrom.php
@@ -17,6 +17,12 @@ class CopyFrom extends Select
 
         $this->placeholder(trans('admin/egg.none'));
 
+        $this->preload();
+
+        $this->searchable();
+
+        $this->native(false);
+
         $this->live();
     }
 

--- a/app/Filament/Server/Resources/FileResource/Pages/EditFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/EditFiles.php
@@ -117,6 +117,8 @@ class EditFiles extends Page
                     ->schema([
                         Select::make('lang')
                             ->label('Syntax Highlighting')
+                            ->searchable()
+                            ->native(false)
                             ->live()
                             ->options(EditorLanguages::class)
                             ->selectablePlaceholder(false)

--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -447,6 +447,8 @@ class ListFiles extends ListRecords
                         ->required(),
                     Select::make('lang')
                         ->label('Syntax Highlighting')
+                        ->searchable()
+                        ->native(false)
                         ->live()
                         ->options(EditorLanguages::class)
                         ->selectablePlaceholder(false)

--- a/resources/views/filament/plugins/monaco-editor.blade.php
+++ b/resources/views/filament/plugins/monaco-editor.blade.php
@@ -119,8 +119,8 @@
                         },
                         wordWrap: 'on',
                         WrappingIndent: 'same',
-
                     });
+                    $el.style.zIndex = '1';
                     monacoEditor(document.getElementById(monacoId).editor);
                     document.getElementById(monacoId).addEventListener('monaco-editor-focused', (event) => {
                         document.getElementById(monacoId).editor.focus();


### PR DESCRIPTION
![{11FDEC7E-AE4C-40FA-92BA-13D9DA3A95B7}](https://github.com/user-attachments/assets/20d30d68-82a4-4729-a657-1440ceb17fe6)

I took the opportunity to add `native(false)` on Edit & Create Egg pages too