### PR TITLE
Update original migrations with nullable

### DIFF
--- a/database/migrations/2016_08_30_213301_modify_ip_storage_method.php
+++ b/database/migrations/2016_08_30_213301_modify_ip_storage_method.php
@@ -11,7 +11,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('servers', function (Blueprint $table) {
-            $table->mediumInteger('allocation')->unsigned()->after('oom_disabled');
+            $table->mediumInteger('allocation')->nullable()->unsigned()->after('oom_disabled');
         });
 
         // Parse All Servers

--- a/database/migrations/2016_09_04_172028_update_failed_jobs_table.php
+++ b/database/migrations/2016_09_04_172028_update_failed_jobs_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('failed_jobs', function (Blueprint $table) {
-            $table->text('exception');
+            $table->text('exception')->nullable();
         });
     }
 

--- a/database/migrations/2016_09_07_163017_add_unique_identifier.php
+++ b/database/migrations/2016_09_07_163017_add_unique_identifier.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('services', function (Blueprint $table) {
-            $table->string('author', 36)->after('id');
+            $table->string('author', 36)->nullable()->after('id');
         });
     }
 

--- a/database/migrations/2016_09_17_194246_add_docker_image_column.php
+++ b/database/migrations/2016_09_17_194246_add_docker_image_column.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('servers', function (Blueprint $table) {
-            $table->string('image')->after('daemonSecret');
+            $table->string('image')->nullable()->after('daemonSecret');
         });
 
         // Populate the column

--- a/database/migrations/2016_10_14_164802_update_api_keys.php
+++ b/database/migrations/2016_10_14_164802_update_api_keys.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('api_keys', function (Blueprint $table) {
-            $table->unsignedInteger('user')->after('id');
+            $table->unsignedInteger('user')->nullable()->after('id');
             $table->text('memo')->after('allowed_ips')->nullable();
             $table->timestamp('expires_at')->after('memo')->nullable();
         });

--- a/database/migrations/2017_01_12_135449_add_more_user_data.php
+++ b/database/migrations/2017_01_12_135449_add_more_user_data.php
@@ -15,7 +15,7 @@ return new class extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->string('name_first')->after('email')->nullable();
             $table->string('name_last')->after('name_first')->nullable();
-            $table->string('username')->after('uuid');
+            $table->string('username')->after('uuid')->nullable();
             $table->boolean('gravatar')->after('totp_secret')->default(true);
         });
 

--- a/database/migrations/2017_03_12_150648_MoveFunctionsFromFileToDatabase.php
+++ b/database/migrations/2017_03_12_150648_MoveFunctionsFromFileToDatabase.php
@@ -44,7 +44,7 @@ EOF;
     public function up(): void
     {
         Schema::table('services', function (Blueprint $table) {
-            $table->text('index_file')->after('startup');
+            $table->text('index_file')->nullable()->after('startup');
         });
 
         DB::transaction(function () {

--- a/database/migrations/2017_03_31_221948_AddServerDescriptionColumn.php
+++ b/database/migrations/2017_03_31_221948_AddServerDescriptionColumn.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('servers', function (Blueprint $table) {
-            $table->text('description')->after('name');
+            $table->text('description')->nullable()->after('name');
         });
     }
 

--- a/database/migrations/2017_10_02_202000_ChangeServicesToUseAMoreUniqueIdentifier.php
+++ b/database/migrations/2017_10_02_202000_ChangeServicesToUseAMoreUniqueIdentifier.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->dropUnique(['file']);
 
             $table->string('author')->change();
-            $table->string('uuid', 36)->after('id');
+            $table->string('uuid', 36)->nullable()->after('id');
             $table->dropColumn('folder');
             $table->dropColumn('startup');
             $table->dropColumn('index_file');

--- a/database/migrations/2017_10_02_202007_ChangeToABetterUniqueServiceConfiguration.php
+++ b/database/migrations/2017_10_02_202007_ChangeToABetterUniqueServiceConfiguration.php
@@ -14,8 +14,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('service_options', function (Blueprint $table) {
-            $table->string('uuid', 36)->after('id');
-            $table->string('author')->after('service_id');
+            $table->string('uuid', 36)->nullable()->after('id');
+            $table->string('author')->nullable()->after('service_id');
             $table->dropColumn('tag');
         });
 

--- a/database/migrations/2018_03_15_124536_add_description_to_nodes.php
+++ b/database/migrations/2018_03_15_124536_add_description_to_nodes.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('nodes', function (Blueprint $table) {
-            $table->text('description')->after('name');
+            $table->text('description')->nullable()->after('name');
         });
     }
 

--- a/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
+++ b/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
@@ -21,8 +21,8 @@ return new class extends Migration
         });
 
         Schema::table('nodes', function (Blueprint $table) {
-            $table->string('uuid', 36)->after('id');
-            $table->string('daemon_token_id', 16)->after('upload_size');
+            $table->string('uuid', 36)->nullable()->after('id');
+            $table->string('daemon_token_id', 16)->nullable()->after('upload_size');
             $table->renameColumn('daemonSecret', 'daemon_token');
         });
 

--- a/database/migrations/2021_01_10_153937_add_file_denylist_to_egg_configs.php
+++ b/database/migrations/2021_01_10_153937_add_file_denylist_to_egg_configs.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('eggs', function (Blueprint $table) {
-            $table->text('file_denylist')->after('docker_images');
+            $table->text('file_denylist')->nullable()->after('docker_images');
         });
     }
 

--- a/database/migrations/2021_01_13_013420_add_cron_month.php
+++ b/database/migrations/2021_01_13_013420_add_cron_month.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('schedules', function (Blueprint $table) {
-            $table->string('cron_month')->after('cron_day_of_week');
+            $table->string('cron_month')->nullable()->after('cron_day_of_week');
         });
     }
 

--- a/database/migrations/2024_03_12_154408_remove_nests_table.php
+++ b/database/migrations/2024_03_12_154408_remove_nests_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('eggs', function (Blueprint $table) {
-            $table->text('tags');
+            $table->text('tags')->nullable();
         });
 
         DB::table('eggs')->update(['tags' => '[]']);

--- a/database/migrations/2024_03_14_055537_remove_locations_table.php
+++ b/database/migrations/2024_03_14_055537_remove_locations_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('nodes', function (Blueprint $table) {
-            $table->text('tags');
+            $table->text('tags')->nullable();
         });
 
         DB::table('nodes')->update(['tags' => '[]']);


### PR DESCRIPTION
The recommended solution is to use migration squashing, but it's also safe to just explicitly declare these migration columns as nullable (as they were assumed to be beforehand anyways).