### PR TITLE
Fix `serverVariables` not saving due to `join`

### DIFF
--- a/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
@@ -426,7 +426,7 @@ class CreateServer extends CreateRecord
 
                                     Repeater::make('server_variables')
                                         ->label('')
-                                        ->relationship('serverVariables')
+                                        ->relationship('serverVariables', fn (Builder $query) => $query->orderByPowerJoins('variable.sort'))
                                         ->saveRelationshipsBeforeChildrenUsing(null)
                                         ->saveRelationshipsUsing(null)
                                         ->grid(2)

--- a/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
@@ -595,9 +595,7 @@ class EditServer extends EditRecord
                                             ]);
                                         }
 
-                                        return $query
-                                            ->join('egg_variables', 'server_variables.variable_id', '=', 'egg_variables.id')
-                                            ->orderBy('egg_variables.sort');
+                                        return $query->orderByPowerJoins('variable.sort');
                                     })
                                     ->grid()
                                     ->mutateRelationshipDataBeforeSaveUsing(function (array &$data): array {

--- a/app/Filament/Server/Pages/Startup.php
+++ b/app/Filament/Server/Pages/Startup.php
@@ -18,6 +18,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Validator;
 
 class Startup extends ServerFormPage
@@ -100,7 +101,7 @@ class Startup extends ServerFormPage
                     ->schema([
                         Repeater::make('server_variables')
                             ->label('')
-                            ->relationship('viewableServerVariables')
+                            ->relationship('viewableServerVariables', fn (Builder $query) => $query->orderByPowerJoins('variable.sort'))
                             ->grid()
                             ->disabled(fn () => !auth()->user()->can(Permission::ACTION_STARTUP_UPDATE, $server))
                             ->reorderable(false)->addable(false)->deletable(false)

--- a/app/Filament/Server/Pages/Startup.php
+++ b/app/Filament/Server/Pages/Startup.php
@@ -101,7 +101,7 @@ class Startup extends ServerFormPage
                     ->schema([
                         Repeater::make('server_variables')
                             ->label('')
-                            ->relationship('viewableServerVariables', fn (Builder $query) => $query->orderByPowerJoins('variable.sort'))
+                            ->relationship('serverVariables', fn (Builder $query) => $query->where('egg_variables.user_viewable', true)->orderByPowerJoins('variable.sort'))
                             ->grid()
                             ->disabled(fn () => !auth()->user()->can(Permission::ACTION_STARTUP_UPDATE, $server))
                             ->reorderable(false)->addable(false)->deletable(false)

--- a/app/Http/Controllers/Api/Client/Servers/StartupController.php
+++ b/app/Http/Controllers/Api/Client/Servers/StartupController.php
@@ -37,7 +37,7 @@ class StartupController extends ClientApiController
         $startup = $this->startupCommandService->handle($server);
 
         return $this->fractal->collection(
-            $server->variables()->orderBy('sort')->where('user_viewable', true)->get()
+            $server->variables()->where('user_viewable', true)->orderBy('sort')->get()
         )
             ->transformWith($this->getTransformer(EggVariableTransformer::class))
             ->addMeta([

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -310,15 +310,6 @@ class Server extends Model implements Validatable
         return $this->hasMany(ServerVariable::class);
     }
 
-    /** @deprecated use serverVariables */
-    public function viewableServerVariables(): HasMany
-    {
-        return $this->serverVariables()
-            ->join('egg_variables', 'egg_variables.id', '=', 'server_variables.variable_id')
-            ->orderBy('egg_variables.sort')
-            ->where('egg_variables.user_viewable', true);
-    }
-
     /**
      * Gets information for the node associated with this server.
      */


### PR DESCRIPTION
[Screencast_20250411_162230.webm](https://github.com/user-attachments/assets/f119f4dd-346c-4428-b100-88842457d8cf)
Bug introduced in #1172

Remove deprecated `viewableServerVariables` method on `Server` model 