### PR TITLE
Only allow `image/png` mimetype for Avatar

### DIFF
--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -130,6 +130,7 @@ class EditProfile extends BaseEditProfile
                                         FileUpload::make('avatar')
                                             ->visible(fn () => config('panel.filament.avatar-provider') === 'local')
                                             ->avatar()
+                                            ->acceptedFileTypes(['image/png'])
                                             ->directory('avatars')
                                             ->getUploadedFileNameForStorageUsing(fn () => $this->getUser()->id . '.png'),
                                     ]),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0dede41e-fe4c-42a2-900f-caabdc721e21)
https://github.com/pelican-dev/panel/blob/702a6bb750ae8acb818d31ad827591970a136f10/app/Extensions/Avatar/Providers/LocalAvatarProvider.php#L18-L23

Ideally we'd support all images format but this is good enough for now