### PR TITLE
Allow users to remove their `Avatar`

### DIFF
--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -131,7 +131,16 @@ class EditProfile extends BaseEditProfile
                                             ->visible(fn () => config('panel.filament.avatar-provider') === 'local')
                                             ->avatar()
                                             ->directory('avatars')
-                                            ->getUploadedFileNameForStorageUsing(fn () => $this->getUser()->id . '.png'),
+                                            ->getUploadedFileNameForStorageUsing(fn () => $this->getUser()->id . '.png')
+                                            ->hintAction(function (FileUpload $fileUpload) {
+                                                $path = $fileUpload->getDirectory() . '/' . $this->getUser()->id . '.png';
+
+                                                return Action::make('remove_avatar')
+                                                    ->icon('tabler-photo-minus')
+                                                    ->iconButton()
+                                                    ->hidden(fn () => !$fileUpload->getDisk()->exists($path))
+                                                    ->action(fn () => $fileUpload->getDisk()->delete($path));
+                                            }),
                                     ]),
 
                                 Tab::make(trans('profile.tabs.oauth'))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1eba6918-786c-4fe7-9d41-1cd22f70ec80)

No idea how we can set it so it has the current avatar as a state since it wants a `TemporaryUploadUrl`