### PR TITLE
Remove `NavigationGroups` for Admin Navbar

### DIFF
--- a/app/Filament/Admin/Resources/EggResource.php
+++ b/app/Filament/Admin/Resources/EggResource.php
@@ -19,11 +19,6 @@ class EggResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function getNavigationGroup(): ?string
-    {
-        return trans('admin/dashboard.server');
-    }
-
     public static function getNavigationLabel(): string
     {
         return trans('admin/egg.nav_title');

--- a/app/Filament/Admin/Resources/NodeResource.php
+++ b/app/Filament/Admin/Resources/NodeResource.php
@@ -30,11 +30,6 @@ class NodeResource extends Resource
         return trans('admin/node.model_label_plural');
     }
 
-    public static function getNavigationGroup(): ?string
-    {
-        return trans('admin/dashboard.server');
-    }
-
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::count() ?: null;

--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -48,7 +48,7 @@ class RoleResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('admin/dashboard.user');
+        return trans('admin/dashboard.advanced');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/ServerResource.php
+++ b/app/Filament/Admin/Resources/ServerResource.php
@@ -29,11 +29,6 @@ class ServerResource extends Resource
         return trans('admin/server.model_label_plural');
     }
 
-    public static function getNavigationGroup(): ?string
-    {
-        return trans('admin/dashboard.server');
-    }
-
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::count() ?: null;

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -43,11 +43,6 @@ class UserResource extends Resource
         return trans('admin/user.model_label_plural');
     }
 
-    public static function getNavigationGroup(): ?string
-    {
-        return trans('admin/dashboard.user');
-    }
-
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::count() ?: null;

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -53,10 +53,6 @@ class AdminPanelProvider extends PanelProvider
                     ->sort(24),
             ])
             ->navigationGroups([
-                NavigationGroup::make(trans('admin/dashboard.server'))
-                    ->collapsible(false),
-                NavigationGroup::make(trans('admin/dashboard.user'))
-                    ->collapsible(false),
                 NavigationGroup::make(trans('admin/dashboard.advanced')),
             ])
             ->sidebarCollapsibleOnDesktop()

--- a/lang/en/admin/dashboard.php
+++ b/lang/en/admin/dashboard.php
@@ -4,8 +4,6 @@ return [
     'heading' => 'Welcome to Pelican!',
     'version' => 'Version: :version',
     'advanced' => 'Advanced',
-    'server' => 'Server',
-    'user' => 'User',
     'sections' => [
         'intro-developers' => [
             'heading' => 'Information for Developers',


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/8920ba07-6d2a-4e9e-8d43-4571ca2d612b)
![image](https://github.com/user-attachments/assets/79d14fbd-7b7d-4ec0-bfef-39b7d417591f)

After
![image](https://github.com/user-attachments/assets/0cea977e-b31a-472b-9ead-ddbd7a978c15)
![image](https://github.com/user-attachments/assets/629bcff9-d6d9-4187-85d8-f265b877ec3b)