### PR TITLE
Fix storage graph not rendering correctly

### DIFF
--- a/app/Filament/Admin/Resources/NodeResource/Widgets/NodeCpuChart.php
+++ b/app/Filament/Admin/Resources/NodeResource/Widgets/NodeCpuChart.php
@@ -23,7 +23,7 @@ class NodeCpuChart extends ChartWidget
         $cpu = collect(cache()->get("nodes.{$this->node->id}.cpu_percent"))
             ->slice(-10)
             ->map(fn ($value, $key) => [
-                'cpu' => Number::format($value * $threads, maxPrecision: 2),
+                'cpu' => round($value * $threads, 2),
                 'timestamp' => Carbon::createFromTimestamp($key, auth()->user()->timezone ?? 'UTC')->format('H:i:s'),
             ])
             ->all();

--- a/app/Filament/Admin/Resources/NodeResource/Widgets/NodeMemoryChart.php
+++ b/app/Filament/Admin/Resources/NodeResource/Widgets/NodeMemoryChart.php
@@ -20,7 +20,7 @@ class NodeMemoryChart extends ChartWidget
     {
         $memUsed = collect(cache()->get("nodes.{$this->node->id}.memory_used"))->slice(-10)
             ->map(fn ($value, $key) => [
-                'memory' => Number::format(config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1000 / 1000 / 1000, maxPrecision: 2),
+                'memory' => round(config('panel.use_binary_prefix') ? $value / 1024 / 1024 / 1024 : $value / 1000 / 1000 / 1000, 2),
                 'timestamp' => Carbon::createFromTimestamp($key, auth()->user()->timezone ?? 'UTC')->format('H:i:s'),
             ])
             ->all();

--- a/app/Filament/Admin/Resources/NodeResource/Widgets/NodeStorageChart.php
+++ b/app/Filament/Admin/Resources/NodeResource/Widgets/NodeStorageChart.php
@@ -46,8 +46,8 @@ class NodeStorageChart extends ChartWidget
 
         $unused = $total - $used;
 
-        $used = Number::format($used, maxPrecision: 2);
-        $unused = Number::format($unused, maxPrecision: 2);
+        $used = round($used, 2);
+        $unused = round($unused, 2);
 
         return [
             'datasets' => [

--- a/app/Filament/Admin/Resources/NodeResource/Widgets/NodeStorageChart.php
+++ b/app/Filament/Admin/Resources/NodeResource/Widgets/NodeStorageChart.php
@@ -4,7 +4,6 @@ namespace App\Filament\Admin\Resources\NodeResource\Widgets;
 
 use App\Models\Node;
 use Filament\Widgets\ChartWidget;
-use Illuminate\Support\Number;
 
 class NodeStorageChart extends ChartWidget
 {


### PR DESCRIPTION
Use round instead of `Number::format` since that adds a comma once it reaches 1k which breaks chartjs render.