### PR TITLE
Correctly display backup status

### DIFF
--- a/app/Enums/BackupStatus.php
+++ b/app/Enums/BackupStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum BackupStatus: string implements HasColor, HasIcon, HasLabel
+{
+    case InProgress = 'in_progress';
+    case Successful = 'successful';
+    case Failed = 'failed';
+
+    public function getIcon(): string
+    {
+        return match ($this) {
+            self::InProgress => 'tabler-circle-dashed',
+            self::Successful => 'tabler-circle-check',
+            self::Failed => 'tabler-circle-x',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::InProgress => 'primary',
+            self::Successful => 'success',
+            self::Failed => 'danger',
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return str($this->value)->headline();
+    }
+}

--- a/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
@@ -77,7 +77,8 @@ class ListBackups extends ListRecords
                 IconColumn::make('is_locked')
                     ->visibleFrom('md')
                     ->label('Lock Status')
-                    ->icon(fn (Backup $backup) => !$backup->is_locked ? 'tabler-lock-open' : 'tabler-lock'),
+                    ->trueIcon('tabler-lock')
+                    ->falseIcon('tabler-lock-open'),
             ])
             ->actions([
                 ActionGroup::make([
@@ -185,7 +186,6 @@ class ListBackups extends ListRecords
                             ->body($backup->name . ' created.')
                             ->success()
                             ->send();
-
                     } catch (HttpException $e) {
                         return Notification::make()
                             ->danger()

--- a/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
@@ -70,9 +70,9 @@ class ListBackups extends ListRecords
                     ->label('Created')
                     ->since()
                     ->sortable(),
-                IconColumn::make('is_successful')
-                    ->label('Successful')
-                    ->boolean(),
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge(),
                 IconColumn::make('is_locked')
                     ->visibleFrom('md')
                     ->label('Lock Status')

--- a/app/Models/Backup.php
+++ b/app/Models/Backup.php
@@ -7,6 +7,8 @@ use App\Traits\HasValidation;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Eloquent\BackupQueryBuilder;
+use App\Enums\BackupStatus;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -23,6 +25,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $bytes
  * @property string|null $upload_id
  * @property \Carbon\CarbonImmutable|null $completed_at
+ * @property BackupStatus $status
  * @property \Carbon\CarbonImmutable $created_at
  * @property \Carbon\CarbonImmutable $updated_at
  * @property \Carbon\CarbonImmutable|null $deleted_at
@@ -77,6 +80,13 @@ class Backup extends Model implements Validatable
             'updated_at' => 'immutable_datetime',
             'deleted_at' => 'immutable_datetime',
         ];
+    }
+
+    protected function status(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => !$this->completed_at ? BackupStatus::InProgress : ($this->is_successful ? BackupStatus::Successful : BackupStatus::Failed),
+        );
     }
 
     public function server(): BelongsTo


### PR DESCRIPTION
Closes #1255

Uses a new `status` attribute instead of just `is_successful` to display the status of a backup.
Also hides actions like download and restore if the backup is still in progress or failed.