### PR TITLE
Add `live()` to `KeyValue`

### DIFF
--- a/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/CreateServer.php
@@ -792,6 +792,7 @@ class CreateServer extends CreateRecord
                                         ]),
 
                                     KeyValue::make('docker_labels')
+                                        ->live()
                                         ->label('Container Labels')
                                         ->keyLabel(trans('admin/server.title'))
                                         ->valueLabel(trans('admin/server.description'))

--- a/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
@@ -486,6 +486,7 @@ class EditServer extends EditRecord
                                             ]),
 
                                         KeyValue::make('docker_labels')
+                                            ->live()
                                             ->label(trans('admin/server.container_labels'))
                                             ->keyLabel(trans('admin/server.title'))
                                             ->valueLabel(trans('admin/server.description'))


### PR DESCRIPTION
Closes #1260
Follow up https://github.com/pelican-dev/panel/issues/164

> FYI this is still an issue. The reason is that the key string is converted directly object access notation when sent over via Livewire. If your component is called "comp" and you have the KeyValue column called "keva" and your key is named "example" with a value of "true...yes", it will normally do `comp.keva.example = "true...yes"` - however if you have a "." in your key name (`example.com`), instead it will do `comp.keva.example.com = "true...yes"`. I'm sure you can see where the problem is. This will cause a failure in the KeyValue component because it's looking for the Key's to be strings, but this casts it to an "array".
> 
> However you can easily bypass this issue for now and just add `->live()` to your KeyValue component and Livewire's binding will appropriately cast `example.com` to a string `"example.com"`.

https://github.com/filamentphp/filament/issues/12116#issuecomment-2097408424