### PR TITLE
Fix `develop` Node Version reported as outdated

### DIFF
--- a/app/Checks/NodeVersionsCheck.php
+++ b/app/Checks/NodeVersionsCheck.php
@@ -14,9 +14,9 @@ class NodeVersionsCheck extends Check
 
     public function run(): Result
     {
-        $all = Node::query()->count();
+        $all = Node::all();
 
-        if ($all === 0) {
+        if ($all->isEmpty()) {
             $result = Result::make()
                 ->notificationMessage(trans('admin/health.results.nodeversions.no_nodes_created'))
                 ->shortSummary(trans('admin/health.results.nodeversions.no_nodes'));
@@ -25,16 +25,18 @@ class NodeVersionsCheck extends Check
             return $result;
         }
 
-        $latestVersion = $this->versionService->latestWingsVersion();
-
-        $outdated = Node::query()->get()
-            ->filter(fn (Node $node) => !isset($node->systemInformation()['exception']) && $node->systemInformation()['version'] !== $latestVersion)
+        $outdated = $all
+            ->filter(fn (Node $node) => !isset($node->systemInformation()['exception']) && !$this->versionService->isLatestWings($node->systemInformation()['version']))
             ->count();
+
+        $all = $all->count();
+        $latestVersion = $this->versionService->latestWingsVersion();
 
         $result = Result::make()
             ->meta([
                 'all' => $all,
                 'outdated' => $outdated,
+                'latestVersion' => $latestVersion,
             ])
             ->shortSummary($outdated === 0 ? trans('admin/health.results.nodeversions.all_up_to_date') : trans('admin/health.results.nodeversions.outdated', ['outdated' => $outdated, 'all' => $all]));
 


### PR DESCRIPTION
If node version didn't match latestWingsVersion it was thought as outdated omitting the `develop` check so use the helper instead
https://github.com/pelican-dev/panel/blob/038504fbec3713ba4274b4310a746798dec3192c/app/Services/Helpers/SoftwareVersionService.php#L55-L62