### PR TITLE
Override section header icon self alignment to centre

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2,3 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 @tailwind variants;
+
+.fi-section-header-icon {
+    @apply !self-center;
+}


### PR DESCRIPTION
greetings,

i'm assuming this cosmetic change is not important right now for you, so i have permitted myself to suggest a modification directly.

i see that so far, most filament section headers in the panel with an icon only have a title, rather than both a title and a description. the default behaviour for section header icons is to `align-self: start`. with the title only being one line, the icon appears off centre with the rest of the vertically aligned header items when there is an action on the right.

example:
![CleanShot 2025-04-19 at 14 47 31@2x](https://github.com/user-attachments/assets/553d0da2-b93b-4b57-8872-a864276958af)

according to the filament [docs](https://filamentphp.com/docs/3.x/support/style-customization), i have added an override to `app.css` for section header icons to be centred vertically. this is a forced rule, but it seems more appropriate with the panels current usage of headers and icons.

after:
![CleanShot 2025-04-19 at 14 13 53@2x](https://github.com/user-attachments/assets/8feabab6-674a-452f-94a6-edcc40916a33)