### PR TITLE
Resolve issue with avatar storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN chown root:www-data ./ \
     && ln -s /pelican-data/.env ./.env \
     && ln -s /pelican-data/database/database.sqlite ./database/database.sqlite \
     && ln -sf /var/www/html/storage/app/public /var/www/html/public/storage \
-    && ln -s  /pelican-data/storage/ /var/www/html/storage/app/public/avatars \
+    && ln -s  /pelican-data/storage/avatars /var/www/html/storage/app/public/avatars \
     # Allow www-data write permissions where necessary 
     && chown -R www-data:www-data /pelican-data ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R u+rwX,g+rwX,o-rwx /pelican-data ./storage ./bootstrap/cache /var/run/supervisord

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,14 +1,18 @@
 # syntax=docker.io/docker/dockerfile:1.13-labs
-# Pelican Production Dockerfile
+# Pelican Development Dockerfile
 
-##
-#  If you want to build this locally you want to run `docker build -f Dockerfile.dev`
-##
+FROM --platform=$TARGETOS/$TARGETARCH php:8.4-fpm-alpine AS base
+
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions bcmath gd intl zip opcache pcntl posix pdo_mysql pdo_pgsql
+
+RUN rm /usr/local/bin/install-php-extensions
 
 # ================================
 # Stage 1-1: Composer Install
 # ================================
-FROM --platform=$TARGETOS/$TARGETARCH localhost:5000/base-php:$TARGETARCH AS composer
+FROM --platform=$TARGETOS/$TARGETARCH base AS composer
 
 WORKDIR /build
 
@@ -58,7 +62,7 @@ RUN yarn run build
 # ================================
 # Stage 5: Build Final Application Image
 # ================================
-FROM --platform=$TARGETOS/$TARGETARCH localhost:5000/base-php:$TARGETARCH AS final
+FROM --platform=$TARGETOS/$TARGETARCH base AS final
 
 WORKDIR /var/www/html
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -85,7 +85,7 @@ RUN chown root:www-data ./ \
     && ln -s /pelican-data/.env ./.env \
     && ln -s /pelican-data/database/database.sqlite ./database/database.sqlite \
     && ln -sf /var/www/html/storage/app/public /var/www/html/public/storage \
-    && ln -s  /pelican-data/storage/ /var/www/html/storage/app/public/avatars \
+    && ln -s  /pelican-data/storage/avatars /var/www/html/storage/app/public/avatars \
     # Allow www-data write permissions where necessary 
     && chown -R www-data:www-data /pelican-data ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R u+rwX,g+rwX,o-rwx /pelican-data ./storage ./bootstrap/cache /var/run/supervisord

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,7 +23,7 @@ else
   echo -e "APP_INSTALLED=false" >> /pelican-data/.env
 fi
 
-mkdir -p /pelican-data/database /pelican/storage /var/www/html/storage/logs/supervisord 2>/dev/null
+mkdir -p /pelican-data/database /pelican-data/storage/avatars /var/www/html/storage/logs/supervisord 2>/dev/null
 
 if ! grep -q "APP_KEY=" .env || grep -q "APP_KEY=$" .env; then
   echo "Generating APP_KEY..."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,7 +23,7 @@ else
   echo -e "APP_INSTALLED=false" >> /pelican-data/.env
 fi
 
-mkdir /pelican-data/database /var/www/html/storage/logs/supervisord 2>/dev/null
+mkdir -p /pelican-data/database /pelican/storage /var/www/html/storage/logs/supervisord 2>/dev/null
 
 if ! grep -q "APP_KEY=" .env || grep -q "APP_KEY=$" .env; then
   echo "Generating APP_KEY..."


### PR DESCRIPTION
This resolves the issue with getting avatar storage working

updates the entrypoint to create the `pelican-data/storage` folder on start.

Adds a dev dockerfile to build locally instead of needing to update the standard dockerfile.