### PR TITLE
feat(console): save command history in session

### DIFF
--- a/app/Filament/Server/Widgets/ServerConsole.php
+++ b/app/Filament/Server/Widgets/ServerConsole.php
@@ -11,6 +11,7 @@ use App\Services\Nodes\NodeJWTService;
 use App\Services\Servers\GetUserPermissionsService;
 use Filament\Widgets\Widget;
 use Illuminate\Support\Arr;
+use Livewire\Attributes\Session;
 use Livewire\Attributes\On;
 
 class ServerConsole extends Widget
@@ -26,6 +27,7 @@ class ServerConsole extends Widget
     public ?User $user = null;
 
     /** @var string[] */
+    #[Session]
     public array $history = [];
 
     public int $historyIndex = 0;

--- a/app/Filament/Server/Widgets/ServerConsole.php
+++ b/app/Filament/Server/Widgets/ServerConsole.php
@@ -27,7 +27,7 @@ class ServerConsole extends Widget
     public ?User $user = null;
 
     /** @var string[] */
-    #[Session]
+    #[Session(key: 'server.{server.id}.history')]
     public array $history = [];
 
     public int $historyIndex = 0;


### PR DESCRIPTION
We can use ``#[Session]`` to have Livewire automatically save the command history in the user's session. 

this will improve the user experience for those who often forget the commands they gave or want to be quick :)
