### PR TITLE
Only use navigation groups when using sidebar

### DIFF
--- a/app/Filament/Admin/Resources/EggResource.php
+++ b/app/Filament/Admin/Resources/EggResource.php
@@ -21,7 +21,7 @@ class EggResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('admin/dashboard.server');
+        return config('panel.filament.top-navigation', false) ? null : trans('admin/dashboard.server');
     }
 
     public static function getNavigationLabel(): string

--- a/app/Filament/Admin/Resources/EggResource.php
+++ b/app/Filament/Admin/Resources/EggResource.php
@@ -19,6 +19,11 @@ class EggResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('admin/dashboard.server');
+    }
+
     public static function getNavigationLabel(): string
     {
         return trans('admin/egg.nav_title');

--- a/app/Filament/Admin/Resources/NodeResource.php
+++ b/app/Filament/Admin/Resources/NodeResource.php
@@ -32,7 +32,7 @@ class NodeResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('admin/dashboard.server');
+        return config('panel.filament.top-navigation', false) ? null : trans('admin/dashboard.server');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/NodeResource.php
+++ b/app/Filament/Admin/Resources/NodeResource.php
@@ -30,6 +30,11 @@ class NodeResource extends Resource
         return trans('admin/node.model_label_plural');
     }
 
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('admin/dashboard.server');
+    }
+
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::count() ?: null;

--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -48,7 +48,7 @@ class RoleResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('admin/dashboard.user');
+        return config('panel.filament.top-navigation', false) ? trans('admin/dashboard.advanced') : trans('admin/dashboard.user');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -48,7 +48,7 @@ class RoleResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('admin/dashboard.advanced');
+        return trans('admin/dashboard.user');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/ServerResource.php
+++ b/app/Filament/Admin/Resources/ServerResource.php
@@ -31,7 +31,7 @@ class ServerResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('admin/dashboard.server');
+        return config('panel.filament.top-navigation', false) ? null : trans('admin/dashboard.server');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/ServerResource.php
+++ b/app/Filament/Admin/Resources/ServerResource.php
@@ -29,6 +29,11 @@ class ServerResource extends Resource
         return trans('admin/server.model_label_plural');
     }
 
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('admin/dashboard.server');
+    }
+
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::count() ?: null;

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -45,7 +45,7 @@ class UserResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return trans('admin/dashboard.user');
+        return config('panel.filament.top-navigation', false) ? null : trans('admin/dashboard.user');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -43,6 +43,11 @@ class UserResource extends Resource
         return trans('admin/user.model_label_plural');
     }
 
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('admin/dashboard.user');
+    }
+
     public static function getNavigationBadge(): ?string
     {
         return static::getModel()::count() ?: null;

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -37,7 +37,7 @@ class AdminPanelProvider extends PanelProvider
             ->brandLogo(config('app.logo'))
             ->brandLogoHeight('2rem')
             ->favicon(config('app.favicon', '/pelican.ico'))
-            ->topNavigation(config('panel.filament.top-navigation', true))
+            ->topNavigation(config('panel.filament.top-navigation', false))
             ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
             ->defaultAvatarProvider(fn () => get_class(AvatarProvider::getProvider(config('panel.filament.avatar-provider'))))
             ->login(Login::class)

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -53,6 +53,10 @@ class AdminPanelProvider extends PanelProvider
                     ->sort(24),
             ])
             ->navigationGroups([
+                NavigationGroup::make(trans('admin/dashboard.server'))
+                    ->collapsible(false),
+                NavigationGroup::make(trans('admin/dashboard.user'))
+                    ->collapsible(false),
                 NavigationGroup::make(trans('admin/dashboard.advanced')),
             ])
             ->sidebarCollapsibleOnDesktop()

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -33,7 +33,7 @@ class AppPanelProvider extends PanelProvider
             ->brandLogo(config('app.logo'))
             ->brandLogoHeight('2rem')
             ->favicon(config('app.favicon', '/pelican.ico'))
-            ->topNavigation(config('panel.filament.top-navigation', true))
+            ->topNavigation(config('panel.filament.top-navigation', false))
             ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
             ->defaultAvatarProvider(fn () => get_class(AvatarProvider::getProvider(config('panel.filament.avatar-provider'))))
             ->navigation(false)

--- a/app/Providers/Filament/ServerPanelProvider.php
+++ b/app/Providers/Filament/ServerPanelProvider.php
@@ -40,7 +40,7 @@ class ServerPanelProvider extends PanelProvider
             ->brandLogo(config('app.logo'))
             ->brandLogoHeight('2rem')
             ->favicon(config('app.favicon', '/pelican.ico'))
-            ->topNavigation(config('panel.filament.top-navigation', true))
+            ->topNavigation(config('panel.filament.top-navigation', false))
             ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
             ->defaultAvatarProvider(fn () => get_class(AvatarProvider::getProvider(config('panel.filament.avatar-provider'))))
             ->login(Login::class)

--- a/lang/en/admin/dashboard.php
+++ b/lang/en/admin/dashboard.php
@@ -4,6 +4,8 @@ return [
     'heading' => 'Welcome to Pelican!',
     'version' => 'Version: :version',
     'advanced' => 'Advanced',
+    'server' => 'Server',
+    'user' => 'User',
     'sections' => [
         'intro-developers' => [
             'heading' => 'Information for Developers',


### PR DESCRIPTION
Follow up for #1248.

Sidebar:
![grafik](https://github.com/user-attachments/assets/f84ed721-114f-475d-b1b4-7f1a509aa46c)

Topbar:
![grafik](https://github.com/user-attachments/assets/2e5aec02-1bc7-40d1-9b73-d7a6ff444b9e)