### PR TITLE
Configure docker PHP for production use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/Caddyfile /etc/caddy/Caddyfile
 # Configure PHP for production
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+COPY docker/pelican-php.ini "$PHP_INI_DIR/conf.d/pelican-php.ini"
 # Add Laravel scheduler to crontab
 COPY docker/crontab /etc/supercronic/crontab
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,8 @@ RUN chown root:www-data ./ \
 # Configure Supervisor
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/Caddyfile /etc/caddy/Caddyfile
+# Configure PHP for production
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Add Laravel scheduler to crontab
 COPY docker/crontab /etc/supercronic/crontab
 

--- a/docker/pelican-php.ini
+++ b/docker/pelican-php.ini
@@ -1,0 +1,5 @@
+; This is the maximum size of a file that can be uploaded. This is important for livewire based uploads.
+; This can not be increased by the user, so it should ideally be higher than a user would ever encounter -> Infinite
+upload_max_filesize = 0
+; See reason given for upload_max_filesize
+post_max_size = 0


### PR DESCRIPTION
As *strongly* recommended on https://hub.docker.com/_/php, configures PHP for production use. Additionally, the upload file size limit is removed entirely to allow for livewire uploads larger than the default 2 MB that PHP ships with.

This pull request does not build because #1251 introduced a build error, but works perfectly fine if the build error is fixed and is ready to merge as-is.