### PR TITLE
Example docker image that can update UID/GID

### DIFF
--- a/Dockerfile.franken
+++ b/Dockerfile.franken
@@ -1,0 +1,163 @@
+# syntax=docker/dockerfile:1
+# Pelican Production Dockerfile using FrankenPHP
+
+# ================================
+# Stage 1-1: Composer Install
+# ================================
+FROM php:8.3-alpine AS composer
+
+WORKDIR /build
+
+# Install composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+# Install required PHP extensions for Composer
+RUN apk add --no-cache \
+    $PHPIZE_DEPS \
+    git \
+    unzip \
+    libzip-dev \
+    icu-dev \
+    libpng-dev \
+    libxml2-dev \
+    oniguruma-dev \
+    && docker-php-ext-install \
+    bcmath \
+    gd \
+    intl \
+    zip \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    mbstring
+
+# Copy bare minimum to install Composer dependencies
+COPY composer.json composer.lock ./
+
+# Install dependencies with --ignore-platform-reqs to bypass extension checks
+RUN composer install --no-dev --no-interaction --no-autoloader --no-scripts --ignore-platform-reqs
+
+# ================================
+# Stage 1-2: Yarn Install
+# ================================
+FROM node:22-alpine AS yarn
+
+WORKDIR /build
+
+# Copy bare minimum to install Yarn dependencies
+COPY package.json yarn.lock ./
+
+RUN yarn config set network-timeout 300000 \
+    && yarn install --frozen-lockfile
+
+# ================================
+# Stage 2-1: Composer Optimize
+# ================================
+FROM composer AS composerbuild
+
+# Copy full code to optimize autoload
+COPY . ./
+
+RUN composer dump-autoload --optimize
+
+# ================================
+# Stage 2-2: Build Frontend Assets
+# ================================
+FROM yarn AS yarnbuild
+
+WORKDIR /build
+
+# Copy full code
+COPY . ./
+COPY --from=composer /build .
+
+RUN yarn run build
+
+# ================================
+# Stage 2-3: Build PHP Extensions
+# ================================
+FROM dunglas/frankenphp:1-php8.3-alpine AS phpextensions
+
+# Install build dependencies and compile PHP extensions
+RUN apk update && apk add --no-cache \
+    icu-dev \
+    libzip-dev \
+    libpng-dev \
+    libxml2-dev \
+    oniguruma-dev \
+    && docker-php-ext-install \
+    bcmath \
+    gd \
+    intl \
+    zip \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    mbstring
+
+# ================================
+# Stage 3: Build Final Application Image
+# ================================
+FROM dunglas/frankenphp:1-php8.3-alpine AS final
+
+# Copy PHP extensions from the phpextensions stage
+COPY --from=phpextensions /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+COPY --from=phpextensions /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+
+# Install only runtime dependencies
+RUN apk update && apk add --no-cache \
+    ca-certificates \
+    curl \
+    supercronic \
+    su-exec \
+    libzip \
+    libpng \
+    icu-libs \
+    libxml2
+
+# Set environment variables for paths
+ENV PELICAN_HOME=/pelican \
+    PELICAN_APP=/pelican/app \
+    PELICAN_CONFIG=/pelican/config \
+    PELICAN_DATA=/pelican/data
+
+# Create abc user and group
+RUN addgroup -g 1000 abc && \
+    adduser -D -u 1000 -G abc -h "$PELICAN_HOME" abc
+
+# Create directory structure
+RUN mkdir -p "$PELICAN_APP" "$PELICAN_CONFIG" "$PELICAN_DATA" \
+    "$PELICAN_DATA/database" "$PELICAN_APP/storage/logs" "$PELICAN_APP/bootstrap/cache"
+
+WORKDIR $PELICAN_APP
+
+# Copy application files
+COPY --chown=abc:abc --chmod=750 --from=composerbuild /build .
+COPY --chown=abc:abc --chmod=750 --from=yarnbuild /build/public ./public
+
+# Copy Docker configuration files
+COPY --chown=abc:abc --chmod=644 docker.franken.d/Caddyfile "$PELICAN_APP/Caddyfile.template"
+COPY --chown=abc:abc --chmod=644 docker.franken.d/crontab /etc/supercronic/crontab
+COPY --chown=root:root --chmod=755 docker.franken.d/entrypoint.sh /entrypoint.sh
+
+# Set permissions and create necessary directories
+RUN mkdir -p /etc/supercronic \
+    # Symlink to config and data paths
+    && ln -s "$PELICAN_CONFIG/.env" ./.env \
+    && ln -s "$PELICAN_CONFIG/Caddyfile" ./Caddyfile \
+    && ln -s "$PELICAN_DATA/database/database.sqlite" ./database/database.sqlite \
+    # Make sure directories and files have proper permissions
+    && chmod -R 750 "$PELICAN_HOME" "$PELICAN_CONFIG" "$PELICAN_DATA" \
+    && chown -R abc:abc "$PELICAN_HOME" "$PELICAN_CONFIG" "$PELICAN_DATA" \
+    && chmod -R 755 ./vendor
+
+HEALTHCHECK --interval=5m --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost/up || exit 1
+
+EXPOSE 80 443
+
+VOLUME $PELICAN_DATA
+VOLUME $PELICAN_CONFIG
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["frankenphp", "run"]

--- a/docker.franken.d/Caddyfile
+++ b/docker.franken.d/Caddyfile
@@ -1,0 +1,46 @@
+{
+    # Global options
+    admin off
+    email {$ADMIN_EMAIL:pelican@example.com}
+    frankenphp
+}
+
+# Common configuration for both HTTP and HTTPS
+(common_config) {
+    # Set the webroot to the public directory
+    root * {$PELICAN_APP:}/public
+
+    # Enable compression
+    encode gzip zstd
+
+    # Execute PHP files and serve assets
+    php_server
+    file_server
+
+    # Route all requests to index.php
+    @notFile {
+        not file
+    }
+    rewrite @notFile /index.php?{query}
+
+    # Handle errors
+    handle_errors {
+        respond "{http.error.status_code} {http.error.status_text}"
+    }
+
+    # Log requests
+    log {
+        output stdout
+        format json
+    }
+}
+
+# HTTPS configuration (port 443)
+{$APP_URL:localhost}:443 {
+    import common_config
+}
+
+# HTTP configuration (port 80)
+http://{$APP_URL:localhost}:80 {
+    import common_config
+}

--- a/docker.franken.d/crontab
+++ b/docker.franken.d/crontab
@@ -1,0 +1,1 @@
+* * * * * php /app/artisan schedule:run

--- a/docker.franken.d/entrypoint.sh
+++ b/docker.franken.d/entrypoint.sh
@@ -1,0 +1,153 @@
+#!/bin/ash -e
+# shellcheck shell=dash
+
+# Set up environment variables for consistent configuration
+export PELICAN_HOME=${PELICAN_HOME:-"/pelican"}
+export PELICAN_APP=${PELICAN_APP:-"$PELICAN_HOME/app"}
+export PELICAN_CONFIG=${PELICAN_CONFIG:-"$PELICAN_HOME/config"}
+export PELICAN_DATA=${PELICAN_DATA:-"$PELICAN_HOME/data"}
+
+# Set Caddy environment variables
+export XDG_DATA_HOME="$PELICAN_DATA"
+export XDG_CONFIG_HOME="$PELICAN_CONFIG"
+
+# Default values for PUID/PGID if not provided
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+echo "Starting with UID: $PUID, GID: $PGID"
+
+# Function to check and update user/group IDs if needed
+check_user() {
+    # Update the abc user and group with the provided IDs
+    if [ "$PUID" != "1000" ] || [ "$PGID" != "1000" ]; then
+        echo "Updating user and group IDs..."
+
+        # Delete and recreate the user and group with new IDs
+        deluser abc
+        addgroup -g "$PGID" abc
+        adduser -D -u "$PUID" -G abc -h "$PELICAN_HOME" abc
+
+        # Update file ownership efficiently, excluding vendor directory
+        echo "Updating file ownership (this may take a while)..."
+        # Update app directory excluding vendor
+        echo "Updating app directory (excluding vendor)..."
+        find "$PELICAN_APP" -path "$PELICAN_APP/vendor" -prune -o -exec chown abc:abc {} \+ 2>/dev/null || true
+
+        # Update config and data directories
+        echo "Updating config and data directories..."
+        chown -R abc:abc "$PELICAN_CONFIG" "$PELICAN_DATA" 2>/dev/null || true
+
+        echo "UID/GID update completed"
+    fi
+}
+
+# Function to initialize the application
+initialize_app() {
+    # Check if a custom Caddyfile exists in the config volume
+    CADDYFILE="$PELICAN_CONFIG/Caddyfile"
+    if [ ! -f "$CADDYFILE" ]; then
+        echo "No custom Caddyfile found in config volume, copying default Caddyfile"
+        cp "$PELICAN_APP/Caddyfile.template" "$CADDYFILE"
+        # No need to change ownership as we're already running as abc user
+    else
+        echo "Using custom Caddyfile from config volume"
+    fi
+
+    # Handle .env file
+    ENVFILE="$PELICAN_CONFIG/.env"
+    if [ ! -f "$ENVFILE" ]; then
+        echo "Creating new .env file from .env.example"
+        cp "$PELICAN_APP/.env.example" "$ENVFILE"
+
+        # Ensure proper permissions on the new file
+        if [ "$(id -u)" != "0" ]; then
+            # We're running as non-root, so make sure the file is group-writable
+            chmod g+rw "$ENVFILE"
+        fi
+    fi
+
+    # Check if APP_KEY needs to be generated
+    if ! grep -q "^APP_KEY=.\+" "$ENVFILE"; then
+        echo "No APP_KEY found, generating one..."
+        php artisan key:generate
+    else
+        echo "APP_KEY is already set in .env file"
+    fi
+
+    # Ensure database directory exists and has proper permissions
+    if [ ! -d "$PELICAN_DATA/database" ]; then
+        echo "Creating database directory"
+        mkdir -p "$PELICAN_DATA/database"
+
+        # Ensure proper permissions on the new directory
+        if [ "$(id -u)" != "0" ]; then
+            # We're running as non-root, so make sure the directory is group-writable
+            chmod g+rwx "$PELICAN_DATA/database"
+        fi
+    fi
+
+    # Make sure the db is set up
+    echo "Migrating Database"
+    cd "$PELICAN_APP"
+    php artisan migrate --force
+
+    echo "Optimizing Filament"
+    php artisan filament:optimize
+
+    # Set default admin credentials if not provided
+    ADMIN_EMAIL=${ADMIN_EMAIL:-"pelican@example.com"}
+    ADMIN_USERNAME=${ADMIN_USERNAME:-"pelican"}
+    ADMIN_PASSWORD=${ADMIN_PASSWORD:-"pelican"}
+
+    # Create default admin user if not already created
+    ADMIN_FLAG_FILE="$PELICAN_CONFIG/.admin_user_created"
+
+    if [ ! -f "$ADMIN_FLAG_FILE" ] && [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
+        echo "Creating initial admin user..."
+        if php artisan p:user:make --email="${ADMIN_EMAIL}" --username="${ADMIN_USERNAME}" --password="${ADMIN_PASSWORD}" --admin=yes; then
+            echo "Admin user created successfully."
+            # Create flag file to indicate admin user has been created
+            touch "$ADMIN_FLAG_FILE"
+            echo "$(date): Initial admin user created with username '${ADMIN_USERNAME}' and email '${ADMIN_EMAIL}'" > "$ADMIN_FLAG_FILE"
+        else
+            echo "Failed to create admin user."
+        fi
+    else
+        if [ -f "$ADMIN_FLAG_FILE" ]; then
+            echo "Admin user was already created previously. To create a new admin user, delete the file: $ADMIN_FLAG_FILE"
+        fi
+    fi
+
+    # Setup Laravel queue worker in background
+    if [ "${ENABLE_QUEUE_WORKER:-}" = "true" ]; then
+        echo "Starting Laravel queue worker"
+        php artisan queue:work --tries=3 &
+    fi
+
+    # Setup Laravel scheduler using supercronic in background
+    if [ "${ENABLE_SCHEDULER:-}" = "true" ]; then
+        echo "Starting Laravel scheduler"
+        supercronic -overlapping /etc/supercronic/crontab &
+    fi
+}
+
+# Main script execution
+if [ "$(id -u)" = "0" ]; then
+    # Check and update user/group IDs if needed
+    check_user
+
+    # Switch to abc user to run the rest of the script
+    echo "Switching to abc user for the rest of the script"
+    cd "$PELICAN_APP"
+    exec su-exec abc:abc "$0" "$@"
+else
+    # Already running as non-root user, just initialize the app
+    initialize_app
+
+    # Starting FrankenPHP with both HTTP and HTTPS support
+    echo "Starting FrankenPHP with both HTTP and HTTPS support (ports 80 and 443)"
+
+    # Execute the command
+    exec "$@"
+fi


### PR DESCRIPTION
I had recently opened an issue to update the UID/GID of the container https://github.com/pelican-dev/panel/issues/1077. This is so that it's easier to mount persistent files and have the proper permissions both within the container and on the host.

While this is not final by any means, it's just an example to show how this could possibly be done. The container does need to be run as root to update permissions, but if that was taken out, you could run the image as a normal user without root.

I also used franken since it included caddy already, just to speed things up a bit.

Nothing runs as root except to change permissions, after which is runs as a normal user. This includes any composer commands as well. The key is also generated using the artisan command and a default admin is created just to get the panel up and running out of the box.

Hopefully we can incorporate some changes to help support changing the uid and gid if you wanted to.