### PR TITLE
move redis only command to if statement in kernel

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -31,8 +31,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // https://laravel.com/docs/10.x/upgrade#redis-cache-tags
-        $schedule->command('cache:prune-stale-tags')->hourly();
+        if (config('cache.default') === 'redis') {
+            // https://laravel.com/docs/10.x/upgrade#redis-cache-tags
+            // This only needs to run when using redis. anything else throws an error.
+            $schedule->command('cache:prune-stale-tags')->hourly();
+        }
 
         // Execute scheduled commands for servers every minute, as if there was a normal cron running.
         $schedule->command(ProcessRunnableCommand::class)->everyMinute()->withoutOverlapping();


### PR DESCRIPTION
Kernel will run this command no matter the setting in the env, per docs, this only applies to cache when it's using redis as the driver, added if statement, no point in having an extra command to run when it will just error out.