### PR TITLE
Fix 500 when searching for empty term

### DIFF
--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -515,8 +515,9 @@ class ListFiles extends ListRecords
                 ->form([
                     TextInput::make('searchTerm')
                         ->placeholder('Enter a search term, e.g. *.txt')
+                        ->required()
                         ->regex('/^[^*]*\*?[^*]*$/')
-                        ->minLength(3),
+                        ->minValue(3),
                 ])
                 ->action(fn ($data) => redirect(SearchFiles::getUrl([
                     'searchTerm' => $data['searchTerm'],


### PR DESCRIPTION
Fixes 500 when searching for "empty". (_not_ #1332)
![grafik](https://github.com/user-attachments/assets/18c1f3f4-303d-456c-a813-389b22f08c44)