### PR TITLE
Cleanup files mount and fix path for global search

### DIFF
--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -46,16 +46,9 @@ class ListFiles extends ListRecords
     protected static string $resource = FileResource::class;
 
     #[Locked]
-    public string $path;
+    public string $path = '/';
 
     private DaemonFileRepository $fileRepository;
-
-    public function mount(?string $path = null): void
-    {
-        parent::mount();
-
-        $this->path = $path ?? '/';
-    }
 
     public function getBreadcrumbs(): array
     {

--- a/app/Filament/Server/Resources/FileResource/Pages/SearchFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/SearchFiles.php
@@ -12,6 +12,7 @@ use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Livewire\Attributes\Locked;
+use Livewire\Attributes\Url;
 
 class SearchFiles extends ListRecords
 {
@@ -22,15 +23,8 @@ class SearchFiles extends ListRecords
     #[Locked]
     public string $searchTerm;
 
-    #[Locked]
-    public string $path;
-
-    public function mount(?string $searchTerm = null, ?string $path = null): void
-    {
-        parent::mount();
-        $this->searchTerm = $searchTerm;
-        $this->path = $path ?? '/';
-    }
+    #[Url]
+    public string $path = '/';
 
     public function getBreadcrumbs(): array
     {


### PR DESCRIPTION
- Overwriting `mount` to get the path & search term in `ListFiles` & `SearchFiles` isn't needed.
- `path` in `SearchFiles` was never correctly filled because of missing `Url` attribute.