### PR TITLE
Fix Composer warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "pelican-dev/panel",
     "description": "The free, open-source game management panel. Supporting Minecraft, Spigot, BungeeCord, and SRCDS servers.",
+    "license": "AGPL-3.0-only",
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4",
         "ext-intl": "*",
@@ -50,7 +51,7 @@
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.5",
         "fakerphp/faker": "^1.23.1",
-        "larastan/larastan": "3.x-dev#5bd1c40edb43a727584081e74e9a1a2a201ea2ee",
+        "larastan/larastan": "3.4.0",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.15.3",
         "laravel/sail": "^1.41",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.5",
         "fakerphp/faker": "^1.23.1",
-        "larastan/larastan": "3.4.0",
+        "larastan/larastan": "^3.4",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.15.3",
         "laravel/sail": "^1.41",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94cc4693569c48b5e97741827213af0d",
+    "content-hash": "a24a7b46deafee826d9c132b6554e97b",
     "packages": [
         {
             "name": "abdelhamiderrahmouni/filament-monaco-editor",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3819408e46a86ddb3019bf36a8f36ee9",
+    "content-hash": "94cc4693569c48b5e97741827213af0d",
     "packages": [
         {
             "name": "abdelhamiderrahmouni/filament-monaco-editor",
@@ -12965,16 +12965,16 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "3.x-dev",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "5bd1c40edb43a727584081e74e9a1a2a201ea2ee"
+                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/5bd1c40edb43a727584081e74e9a1a2a201ea2ee",
-                "reference": "5bd1c40edb43a727584081e74e9a1a2a201ea2ee",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/1042fa0c2ee490bb6da7381f3323f7292ad68222",
+                "reference": "1042fa0c2ee490bb6da7381f3323f7292ad68222",
                 "shasum": ""
             },
             "require": {
@@ -13003,7 +13003,6 @@
             "suggest": {
                 "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
             },
-            "default-branch": true,
             "type": "phpstan-extension",
             "extra": {
                 "phpstan": {
@@ -13043,7 +13042,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/3.x"
+                "source": "https://github.com/larastan/larastan/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -13051,7 +13050,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-24T07:26:41+00:00"
+            "time": "2025-04-22T09:44:59+00:00"
         },
         {
             "name": "laravel/pail",
@@ -15967,9 +15966,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "larastan/larastan": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -15980,9 +15977,9 @@
         "ext-pdo": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This is a fix for the following warnings:
```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
# General warnings
- No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
- The package "larastan/larastan" is pointing to a commit-ref, this is bad practice and can cause unforeseen issues.
```

Accompanying discussion on the discord: https://discord.com/channels/1218730176297439332/1371963324924825660