### PR TITLE
Only include "server" subjects in activity log query

### DIFF
--- a/app/Filament/Server/Resources/ActivityResource.php
+++ b/app/Filament/Server/Resources/ActivityResource.php
@@ -30,7 +30,7 @@ class ActivityResource extends Resource
         /** @var Server $server */
         $server = Filament::getTenant();
 
-        return ActivityLog::whereHas('subjects', fn (Builder $query) => $query->where('subject_id', $server->id))
+        return ActivityLog::whereHas('subjects', fn (Builder $query) => $query->where('subject_id', $server->id)->where('subject_type', $server->getMorphClass()))
             ->whereNotIn('activity_logs.event', ActivityLog::DISABLED_EVENTS)
             ->when(config('activity.hide_admin_activity'), function (Builder $builder) use ($server) {
                 // We could do this with a query and a lot of joins, but that gets pretty


### PR DESCRIPTION
Fixes user logs showing in the logs of a server if they have the same id.

Example, Server 1 and User 1:
Before:
![grafik](https://github.com/user-attachments/assets/05a4447c-7eb9-4d4d-88a4-339bbf7bbc56)

After:
![grafik](https://github.com/user-attachments/assets/50dadaf3-970d-48ca-8292-4ece4a26dbd9)