### PR TITLE
Put `whereHas`-`orDoesntHave` in own `where`

### DIFF
--- a/app/Filament/Admin/Resources/DatabaseHostResource.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource.php
@@ -164,8 +164,10 @@ class DatabaseHostResource extends Resource
     {
         $query = parent::getEloquentQuery();
 
-        return $query->whereHas('nodes', function (Builder $query) {
-            $query->whereIn('nodes.id', auth()->user()->accessibleNodes()->pluck('id'));
-        })->orDoesntHave('nodes');
+        return $query->where(function (Builder $query) {
+            return $query->whereHas('nodes', function (Builder $query) {
+                $query->whereIn('nodes.id', auth()->user()->accessibleNodes()->pluck('id'));
+            })->orDoesntHave('nodes');
+        });
     }
 }

--- a/app/Filament/Admin/Resources/MountResource.php
+++ b/app/Filament/Admin/Resources/MountResource.php
@@ -176,8 +176,10 @@ class MountResource extends Resource
     {
         $query = parent::getEloquentQuery();
 
-        return $query->whereHas('nodes', function (Builder $query) {
-            $query->whereIn('nodes.id', auth()->user()->accessibleNodes()->pluck('id'));
-        })->orDoesntHave('nodes');
+        return $query->where(function (Builder $query) {
+            return $query->whereHas('nodes', function (Builder $query) {
+                $query->whereIn('nodes.id', auth()->user()->accessibleNodes()->pluck('id'));
+            })->orDoesntHave('nodes');
+        });
     }
 }


### PR DESCRIPTION
Closes #1381

The `whereHas`-`orDoesntHave` checks need to be inside their own `where` to make sure the parenthesis on the query are correct.