### PR TITLE
Use `app` panel for password link in AccountCreated notification

### DIFF
--- a/app/Notifications/AccountCreated.php
+++ b/app/Notifications/AccountCreated.php
@@ -30,7 +30,7 @@ class AccountCreated extends Notification implements ShouldQueue
             ->line('Email: ' . $notifiable->email);
 
         if (!is_null($this->token)) {
-            return $message->action('Setup Your Account', Filament::getResetPasswordUrl($this->token, $notifiable));
+            return $message->action('Setup Your Account', Filament::getPanel('app')->getResetPasswordUrl($this->token, $notifiable));
         }
 
         return $message;


### PR DESCRIPTION
By default it will use the current panel, which means the `admin` panel. That means that the password reset url will use the admin panel as well.

This changes it to always use the `app` panel.