### PR TITLE
Trait-ify resources and add customizable options

### DIFF
--- a/app/Filament/Admin/Resources/ApiKeyResource.php
+++ b/app/Filament/Admin/Resources/ApiKeyResource.php
@@ -8,6 +8,7 @@ use App\Filament\Components\Tables\Columns\DateTimeColumn;
 use App\Models\ApiKey;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TagsInput;
@@ -25,6 +26,7 @@ class ApiKeyResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
     use CanModifyTable;
 
     protected static ?string $model = ApiKey::class;
@@ -99,7 +101,7 @@ class ApiKeyResource extends Resource
             ]);
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         return $form
             ->schema([

--- a/app/Filament/Admin/Resources/ApiKeyResource.php
+++ b/app/Filament/Admin/Resources/ApiKeyResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\ApiKeyResource\Pages;
 use App\Filament\Admin\Resources\UserResource\Pages\EditUser;
 use App\Filament\Components\Tables\Columns\DateTimeColumn;
 use App\Models\ApiKey;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
@@ -20,6 +21,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 class ApiKeyResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = ApiKey::class;
 
     protected static ?string $navigationIcon = 'tabler-key';

--- a/app/Filament/Admin/Resources/ApiKeyResource.php
+++ b/app/Filament/Admin/Resources/ApiKeyResource.php
@@ -8,6 +8,7 @@ use App\Filament\Components\Tables\Columns\DateTimeColumn;
 use App\Models\ApiKey;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
@@ -24,6 +25,7 @@ class ApiKeyResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = ApiKey::class;
 
@@ -61,7 +63,7 @@ class ApiKeyResource extends Resource
         return trans('admin/dashboard.advanced');
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Admin/Resources/ApiKeyResource.php
+++ b/app/Filament/Admin/Resources/ApiKeyResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\ApiKeyResource\Pages;
 use App\Filament\Admin\Resources\UserResource\Pages\EditUser;
 use App\Filament\Components\Tables\Columns\DateTimeColumn;
 use App\Models\ApiKey;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TagsInput;
@@ -21,6 +22,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class ApiKeyResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = ApiKey::class;
@@ -145,7 +147,7 @@ class ApiKeyResource extends Resource
             ]);
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListApiKeys::route('/'),

--- a/app/Filament/Admin/Resources/DatabaseHostResource.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource.php
@@ -7,6 +7,7 @@ use App\Filament\Admin\Resources\DatabaseHostResource\RelationManagers;
 use App\Models\DatabaseHost;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -26,6 +27,7 @@ class DatabaseHostResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
     use CanModifyTable;
 
     protected static ?string $model = DatabaseHost::class;
@@ -97,7 +99,7 @@ class DatabaseHostResource extends Resource
             ]);
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         return $form
             ->schema([

--- a/app/Filament/Admin/Resources/DatabaseHostResource.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Admin\Resources;
 use App\Filament\Admin\Resources\DatabaseHostResource\Pages;
 use App\Filament\Admin\Resources\DatabaseHostResource\RelationManagers;
 use App\Models\DatabaseHost;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -22,6 +23,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class DatabaseHostResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = DatabaseHost::class;
@@ -161,7 +163,7 @@ class DatabaseHostResource extends Resource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListDatabaseHosts::route('/'),

--- a/app/Filament/Admin/Resources/DatabaseHostResource.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource.php
@@ -7,6 +7,7 @@ use App\Filament\Admin\Resources\DatabaseHostResource\RelationManagers;
 use App\Models\DatabaseHost;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -25,6 +26,7 @@ class DatabaseHostResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = DatabaseHost::class;
 
@@ -57,7 +59,7 @@ class DatabaseHostResource extends Resource
         return trans('admin/dashboard.advanced');
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Admin/Resources/DatabaseHostResource.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource.php
@@ -3,7 +3,9 @@
 namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\DatabaseHostResource\Pages;
+use App\Filament\Admin\Resources\DatabaseHostResource\RelationManagers;
 use App\Models\DatabaseHost;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -20,6 +22,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 class DatabaseHostResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = DatabaseHost::class;
 
     protected static ?string $navigationIcon = 'tabler-database';
@@ -148,6 +152,13 @@ class DatabaseHostResource extends Resource
                             ->relationship('nodes', 'name', fn (Builder $query) => $query->whereIn('nodes.id', auth()->user()->accessibleNodes()->pluck('id'))),
                     ]),
             ]);
+    }
+
+    public static function getDefaultRelations(): array
+    {
+        return [
+            RelationManagers\DatabasesRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Admin/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource/Pages/EditDatabaseHost.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Admin\Resources\DatabaseHostResource\Pages;
 
 use App\Filament\Admin\Resources\DatabaseHostResource;
-use App\Filament\Admin\Resources\DatabaseHostResource\RelationManagers\DatabasesRelationManager;
 use App\Models\DatabaseHost;
 use App\Services\Databases\Hosts\HostUpdateService;
 use Filament\Actions\DeleteAction;
@@ -36,17 +35,6 @@ class EditDatabaseHost extends EditRecord
 
     protected function getFormActions(): array
     {
-        return [];
-    }
-
-    public function getRelationManagers(): array
-    {
-        if (DatabasesRelationManager::canViewForRecord($this->getRecord(), static::class)) {
-            return [
-                DatabasesRelationManager::class,
-            ];
-        }
-
         return [];
     }
 

--- a/app/Filament/Admin/Resources/DatabaseHostResource/Pages/ViewDatabaseHost.php
+++ b/app/Filament/Admin/Resources/DatabaseHostResource/Pages/ViewDatabaseHost.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Admin\Resources\DatabaseHostResource\Pages;
 
 use App\Filament\Admin\Resources\DatabaseHostResource;
-use App\Filament\Admin\Resources\DatabaseHostResource\RelationManagers\DatabasesRelationManager;
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
 
@@ -16,16 +15,5 @@ class ViewDatabaseHost extends ViewRecord
         return [
             EditAction::make(),
         ];
-    }
-
-    public function getRelationManagers(): array
-    {
-        if (DatabasesRelationManager::canViewForRecord($this->getRecord(), static::class)) {
-            return [
-                DatabasesRelationManager::class,
-            ];
-        }
-
-        return [];
     }
 }

--- a/app/Filament/Admin/Resources/EggResource.php
+++ b/app/Filament/Admin/Resources/EggResource.php
@@ -3,11 +3,15 @@
 namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\EggResource\Pages;
+use App\Filament\Admin\Resources\EggResource\RelationManagers;
 use App\Models\Egg;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Resources\Resource;
 
 class EggResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = Egg::class;
 
     protected static ?string $navigationIcon = 'tabler-eggs';
@@ -42,6 +46,13 @@ class EggResource extends Resource
     public static function getGloballySearchableAttributes(): array
     {
         return ['name', 'tags', 'uuid', 'id'];
+    }
+
+    public static function getDefaultRelations(): array
+    {
+        return [
+            RelationManagers\ServersRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Admin/Resources/EggResource.php
+++ b/app/Filament/Admin/Resources/EggResource.php
@@ -5,11 +5,13 @@ namespace App\Filament\Admin\Resources;
 use App\Filament\Admin\Resources\EggResource\Pages;
 use App\Filament\Admin\Resources\EggResource\RelationManagers;
 use App\Models\Egg;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Resources\Resource;
 
 class EggResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = Egg::class;
@@ -55,7 +57,7 @@ class EggResource extends Resource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListEggs::route('/'),

--- a/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
@@ -4,7 +4,6 @@ namespace App\Filament\Admin\Resources\EggResource\Pages;
 
 use AbdelhamidErrahmouni\FilamentMonacoEditor\MonacoEditor;
 use App\Filament\Admin\Resources\EggResource;
-use App\Filament\Admin\Resources\EggResource\RelationManagers\ServersRelationManager;
 use App\Filament\Components\Actions\ExportEggAction;
 use App\Filament\Components\Actions\ImportEggAction;
 use App\Filament\Components\Forms\Fields\CopyFrom;
@@ -272,12 +271,5 @@ class EditEgg extends EditRecord
     protected function getFormActions(): array
     {
         return [];
-    }
-
-    public function getRelationManagers(): array
-    {
-        return [
-            ServersRelationManager::class,
-        ];
     }
 }

--- a/app/Filament/Admin/Resources/MountResource.php
+++ b/app/Filament/Admin/Resources/MountResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\MountResource\Pages;
 use App\Models\Mount;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Section;
@@ -23,6 +24,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class MountResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = Mount::class;
@@ -165,7 +167,7 @@ class MountResource extends Resource
             ]);
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListMounts::route('/'),

--- a/app/Filament/Admin/Resources/MountResource.php
+++ b/app/Filament/Admin/Resources/MountResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\MountResource\Pages;
 use App\Models\Mount;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -22,6 +23,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 class MountResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = Mount::class;
 
     protected static ?string $navigationIcon = 'tabler-layers-linked';

--- a/app/Filament/Admin/Resources/MountResource.php
+++ b/app/Filament/Admin/Resources/MountResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\MountResource\Pages;
 use App\Models\Mount;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -26,6 +27,7 @@ class MountResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = Mount::class;
 
@@ -58,7 +60,7 @@ class MountResource extends Resource
         return trans('admin/dashboard.advanced');
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Admin/Resources/MountResource.php
+++ b/app/Filament/Admin/Resources/MountResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\MountResource\Pages;
 use App\Models\Mount;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Group;
 use Filament\Forms\Components\Section;
@@ -27,6 +28,7 @@ class MountResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
     use CanModifyTable;
 
     protected static ?string $model = Mount::class;
@@ -101,7 +103,7 @@ class MountResource extends Resource
             ]);
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         return $form
             ->schema([

--- a/app/Filament/Admin/Resources/NodeResource.php
+++ b/app/Filament/Admin/Resources/NodeResource.php
@@ -5,11 +5,14 @@ namespace App\Filament\Admin\Resources;
 use App\Filament\Admin\Resources\NodeResource\Pages;
 use App\Filament\Admin\Resources\NodeResource\RelationManagers;
 use App\Models\Node;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Builder;
 
 class NodeResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = Node::class;
 
     protected static ?string $navigationIcon = 'tabler-server-2';
@@ -41,7 +44,7 @@ class NodeResource extends Resource
         return (string) static::getEloquentQuery()->count() ?: null;
     }
 
-    public static function getRelations(): array
+    public static function getDefaultRelations(): array
     {
         return [
             RelationManagers\AllocationsRelationManager::class,

--- a/app/Filament/Admin/Resources/NodeResource.php
+++ b/app/Filament/Admin/Resources/NodeResource.php
@@ -5,12 +5,14 @@ namespace App\Filament\Admin\Resources;
 use App\Filament\Admin\Resources\NodeResource\Pages;
 use App\Filament\Admin\Resources\NodeResource\RelationManagers;
 use App\Models\Node;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Builder;
 
 class NodeResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = Node::class;
@@ -52,7 +54,7 @@ class NodeResource extends Resource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListNodes::route('/'),

--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\RoleResource\Pages;
 use App\Models\Role;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Component;
@@ -30,6 +31,7 @@ class RoleResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = Role::class;
 
@@ -62,7 +64,7 @@ class RoleResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\RoleResource\Pages;
 use App\Models\Role;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Component;
@@ -26,6 +27,8 @@ use Spatie\Permission\Contracts\Permission;
 
 class RoleResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = Role::class;
 
     protected static ?string $navigationIcon = 'tabler-users-group';

--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\RoleResource\Pages;
 use App\Models\Role;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
@@ -31,6 +32,7 @@ class RoleResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
     use CanModifyTable;
 
     protected static ?string $model = Role::class;
@@ -104,7 +106,7 @@ class RoleResource extends Resource
             ]);
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         $permissionSections = [];
 

--- a/app/Filament/Admin/Resources/RoleResource.php
+++ b/app/Filament/Admin/Resources/RoleResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\RoleResource\Pages;
 use App\Models\Role;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
@@ -27,6 +28,7 @@ use Spatie\Permission\Contracts\Permission;
 
 class RoleResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = Role::class;
@@ -201,7 +203,7 @@ class RoleResource extends Resource
             ]);
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListRoles::route('/'),

--- a/app/Filament/Admin/Resources/ServerResource.php
+++ b/app/Filament/Admin/Resources/ServerResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\ServerResource\Pages;
 use App\Filament\Admin\Resources\ServerResource\RelationManagers;
 use App\Models\Mount;
 use App\Models\Server;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Get;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class ServerResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = Server::class;
@@ -77,7 +79,7 @@ class ServerResource extends Resource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListServers::route('/'),

--- a/app/Filament/Admin/Resources/ServerResource.php
+++ b/app/Filament/Admin/Resources/ServerResource.php
@@ -3,8 +3,10 @@
 namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\ServerResource\Pages;
+use App\Filament\Admin\Resources\ServerResource\RelationManagers;
 use App\Models\Mount;
 use App\Models\Server;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Get;
 use Filament\Resources\Resource;
@@ -12,6 +14,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 class ServerResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = Server::class;
 
     protected static ?string $navigationIcon = 'tabler-brand-docker';
@@ -64,6 +68,13 @@ class ServerResource extends Resource
             ->helperText(fn () => $allowedMounts->isEmpty() ? trans('admin/server.no_mounts') : null)
             ->bulkToggleable()
             ->columnSpanFull();
+    }
+
+    public static function getDefaultRelations(): array
+    {
+        return [
+            RelationManagers\AllocationsRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/ServerResource/Pages/EditServer.php
@@ -5,7 +5,6 @@ namespace App\Filament\Admin\Resources\ServerResource\Pages;
 use AbdelhamidErrahmouni\FilamentMonacoEditor\MonacoEditor;
 use App\Enums\SuspendAction;
 use App\Filament\Admin\Resources\ServerResource;
-use App\Filament\Admin\Resources\ServerResource\RelationManagers\AllocationsRelationManager;
 use App\Filament\Components\Forms\Actions\PreviewStartupAction;
 use App\Filament\Components\Forms\Actions\RotateDatabasePasswordAction;
 use App\Filament\Server\Pages\Console;
@@ -1134,13 +1133,6 @@ class EditServer extends EditRecord
     protected function getSavedNotification(): ?Notification
     {
         return null;
-    }
-
-    public function getRelationManagers(): array
-    {
-        return [
-            AllocationsRelationManager::class,
-        ];
     }
 
     private function shouldHideComponent(ServerVariable $serverVariable, Forms\Components\Component $component): bool

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -8,6 +8,7 @@ use App\Models\Role;
 use App\Models\User;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
@@ -26,6 +27,7 @@ class UserResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = User::class;
 
@@ -58,7 +60,7 @@ class UserResource extends Resource
         return static::getModel()::count() ?: null;
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\UserResource\Pages;
 use App\Filament\Admin\Resources\UserResource\RelationManagers;
 use App\Models\Role;
 use App\Models\User;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\CheckboxList;
@@ -23,6 +24,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class UserResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = User::class;
@@ -156,7 +158,7 @@ class UserResource extends Resource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListUsers::route('/'),

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -8,6 +8,7 @@ use App\Models\Role;
 use App\Models\User;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\CheckboxList;
@@ -27,6 +28,7 @@ class UserResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
     use CanModifyTable;
 
     protected static ?string $model = User::class;
@@ -106,7 +108,7 @@ class UserResource extends Resource
             ]);
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         return $form
             ->columns(['default' => 1, 'lg' => 3])

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\UserResource\Pages;
 use App\Filament\Admin\Resources\UserResource\RelationManagers;
 use App\Models\Role;
 use App\Models\User;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
@@ -22,6 +23,8 @@ use Illuminate\Database\Eloquent\Builder;
 
 class UserResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = User::class;
 
     protected static ?string $navigationIcon = 'tabler-users';
@@ -146,7 +149,7 @@ class UserResource extends Resource
             ]);
     }
 
-    public static function getRelations(): array
+    public static function getDefaultRelations(): array
     {
         return [
             RelationManagers\ServersRelationManager::class,

--- a/app/Filament/Admin/Resources/WebhookResource.php
+++ b/app/Filament/Admin/Resources/WebhookResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\WebhookResource\Pages;
 use App\Models\WebhookConfiguration;
+use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
@@ -19,6 +20,7 @@ use Filament\Tables\Table;
 
 class WebhookResource extends Resource
 {
+    use CanCustomizePages;
     use CanCustomizeRelations;
 
     protected static ?string $model = WebhookConfiguration::class;
@@ -101,7 +103,7 @@ class WebhookResource extends Resource
             ]);
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListWebhookConfigurations::route('/'),

--- a/app/Filament/Admin/Resources/WebhookResource.php
+++ b/app/Filament/Admin/Resources/WebhookResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\WebhookResource\Pages;
 use App\Models\WebhookConfiguration;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -22,6 +23,7 @@ class WebhookResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = WebhookConfiguration::class;
 
@@ -54,7 +56,7 @@ class WebhookResource extends Resource
         return trans('admin/dashboard.advanced');
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Admin/Resources/WebhookResource.php
+++ b/app/Filament/Admin/Resources/WebhookResource.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\WebhookResource\Pages;
 use App\Models\WebhookConfiguration;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
@@ -23,6 +24,7 @@ class WebhookResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
     use CanModifyTable;
 
     protected static ?string $model = WebhookConfiguration::class;
@@ -82,7 +84,7 @@ class WebhookResource extends Resource
             ]);
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         return $form
             ->schema([

--- a/app/Filament/Admin/Resources/WebhookResource.php
+++ b/app/Filament/Admin/Resources/WebhookResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Resources;
 
 use App\Filament\Admin\Resources\WebhookResource\Pages;
 use App\Models\WebhookConfiguration;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -18,6 +19,8 @@ use Filament\Tables\Table;
 
 class WebhookResource extends Resource
 {
+    use CanCustomizeRelations;
+
     protected static ?string $model = WebhookConfiguration::class;
 
     protected static ?string $navigationIcon = 'tabler-webhook';

--- a/app/Filament/Server/Pages/ServerFormPage.php
+++ b/app/Filament/Server/Pages/ServerFormPage.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Server\Pages;
 
 use App\Models\Server;
+use App\Traits\Filament\BlockAccessInConflict;
 use Filament\Facades\Filament;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Form;
@@ -14,6 +15,7 @@ use Filament\Pages\Page;
  */
 abstract class ServerFormPage extends Page
 {
+    use BlockAccessInConflict;
     use InteractsWithFormActions;
     use InteractsWithForms;
 
@@ -63,18 +65,5 @@ abstract class ServerFormPage extends Page
         $server = Filament::getTenant();
 
         return $server;
-    }
-
-    // TODO: find better way handle server conflict state
-    public static function canAccess(): bool
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if ($server->isInConflictState()) {
-            return false;
-        }
-
-        return parent::canAccess();
     }
 }

--- a/app/Filament/Server/Resources/ActivityResource.php
+++ b/app/Filament/Server/Resources/ActivityResource.php
@@ -8,6 +8,8 @@ use App\Models\Permission;
 use App\Models\Role;
 use App\Models\Server;
 use App\Models\User;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Builder;
@@ -15,6 +17,9 @@ use Illuminate\Database\Query\JoinClause;
 
 class ActivityResource extends Resource
 {
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+
     protected static ?string $model = ActivityLog::class;
 
     protected static ?string $modelLabel = 'Activity';
@@ -56,7 +61,7 @@ class ActivityResource extends Resource
         return auth()->user()->can(Permission::ACTION_ACTIVITY_READ, Filament::getTenant());
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListActivities::route('/'),

--- a/app/Filament/Server/Resources/ActivityResource.php
+++ b/app/Filament/Server/Resources/ActivityResource.php
@@ -12,6 +12,7 @@ use App\Models\Server;
 use App\Models\User;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\DateTimePicker;
@@ -32,6 +33,7 @@ class ActivityResource extends Resource
 {
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = ActivityLog::class;
 
@@ -43,7 +45,7 @@ class ActivityResource extends Resource
 
     protected static ?string $navigationIcon = 'tabler-stack';
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         /** @var Server $server */
         $server = Filament::getTenant();

--- a/app/Filament/Server/Resources/AllocationResource.php
+++ b/app/Filament/Server/Resources/AllocationResource.php
@@ -6,12 +6,17 @@ use App\Filament\Server\Resources\AllocationResource\Pages;
 use App\Models\Allocation;
 use App\Models\Permission;
 use App\Models\Server;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
 
 class AllocationResource extends Resource
 {
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+
     protected static ?string $model = Allocation::class;
 
     protected static ?string $modelLabel = 'Network';
@@ -55,7 +60,7 @@ class AllocationResource extends Resource
         return auth()->user()->can(Permission::ACTION_ALLOCATION_DELETE, Filament::getTenant());
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListAllocations::route('/'),

--- a/app/Filament/Server/Resources/AllocationResource.php
+++ b/app/Filament/Server/Resources/AllocationResource.php
@@ -9,6 +9,7 @@ use App\Models\Permission;
 use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\DetachAction;
@@ -23,6 +24,7 @@ class AllocationResource extends Resource
     use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = Allocation::class;
 
@@ -34,7 +36,7 @@ class AllocationResource extends Resource
 
     protected static ?string $navigationIcon = 'tabler-network';
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         /** @var Server $server */
         $server = Filament::getTenant();

--- a/app/Filament/Server/Resources/AllocationResource.php
+++ b/app/Filament/Server/Resources/AllocationResource.php
@@ -5,7 +5,7 @@ namespace App\Filament\Server\Resources;
 use App\Filament\Server\Resources\AllocationResource\Pages;
 use App\Models\Allocation;
 use App\Models\Permission;
-use App\Models\Server;
+use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class AllocationResource extends Resource
 {
+    use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
 
@@ -26,19 +27,6 @@ class AllocationResource extends Resource
     protected static ?int $navigationSort = 7;
 
     protected static ?string $navigationIcon = 'tabler-network';
-
-    // TODO: find better way handle server conflict state
-    public static function canAccess(): bool
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if ($server->isInConflictState()) {
-            return false;
-        }
-
-        return parent::canAccess();
-    }
 
     public static function canViewAny(): bool
     {

--- a/app/Filament/Server/Resources/BackupResource.php
+++ b/app/Filament/Server/Resources/BackupResource.php
@@ -6,6 +6,7 @@ use App\Filament\Server\Resources\BackupResource\Pages;
 use App\Models\Backup;
 use App\Models\Permission;
 use App\Models\Server;
+use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class BackupResource extends Resource
 {
+    use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
 
@@ -51,19 +53,6 @@ class BackupResource extends Resource
 
         return $count >= $limit ? 'danger'
             : ($count >= $limit * self::WARNING_THRESHOLD ? 'warning' : 'success');
-    }
-
-    // TODO: find better way handle server conflict state
-    public static function canAccess(): bool
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if ($server->isInConflictState()) {
-            return false;
-        }
-
-        return parent::canAccess();
     }
 
     public static function canViewAny(): bool

--- a/app/Filament/Server/Resources/BackupResource.php
+++ b/app/Filament/Server/Resources/BackupResource.php
@@ -6,12 +6,17 @@ use App\Filament\Server\Resources\BackupResource\Pages;
 use App\Models\Backup;
 use App\Models\Permission;
 use App\Models\Server;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
 
 class BackupResource extends Resource
 {
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+
     protected static ?string $model = Backup::class;
 
     protected static ?int $navigationSort = 3;
@@ -76,7 +81,7 @@ class BackupResource extends Resource
         return auth()->user()->can(Permission::ACTION_BACKUP_DELETE, Filament::getTenant());
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListBackups::route('/'),

--- a/app/Filament/Server/Resources/BackupResource.php
+++ b/app/Filament/Server/Resources/BackupResource.php
@@ -19,6 +19,7 @@ use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
+use App\Traits\Filament\HasLimitBadge;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Placeholder;
@@ -44,6 +45,7 @@ class BackupResource extends Resource
     use CanCustomizeRelations;
     use CanModifyForm;
     use CanModifyTable;
+    use HasLimitBadge;
 
     protected static ?string $model = Backup::class;
 
@@ -53,31 +55,20 @@ class BackupResource extends Resource
 
     protected static bool $canCreateAnother = false;
 
-    public const WARNING_THRESHOLD = 0.7;
-
-    public static function getNavigationBadge(): string
+    protected static function getBadgeCount(): int
     {
         /** @var Server $server */
         $server = Filament::getTenant();
 
-        $limit = $server->backup_limit;
-
-        return $server->backups->count() . ($limit === 0 ? '' : ' / ' . $limit);
+        return $server->backups->count();
     }
 
-    public static function getNavigationBadgeColor(): ?string
+    protected static function getBadgeLimit(): int
     {
         /** @var Server $server */
         $server = Filament::getTenant();
 
-        $limit = $server->backup_limit;
-        $count = $server->backups->count();
-
-        if ($limit === 0) {
-            return null;
-        }
-
-        return $count >= $limit ? 'danger' : ($count >= $limit * self::WARNING_THRESHOLD ? 'warning' : 'success');
+        return $server->backup_limit;
     }
 
     public static function defaultForm(Form $form): Form

--- a/app/Filament/Server/Resources/BackupResource.php
+++ b/app/Filament/Server/Resources/BackupResource.php
@@ -17,6 +17,8 @@ use App\Filament\Components\Tables\Columns\DateTimeColumn;
 use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Placeholder;
@@ -40,6 +42,8 @@ class BackupResource extends Resource
     use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
+    use CanModifyTable;
 
     protected static ?string $model = Backup::class;
 
@@ -76,7 +80,7 @@ class BackupResource extends Resource
         return $count >= $limit ? 'danger' : ($count >= $limit * self::WARNING_THRESHOLD ? 'warning' : 'success');
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         return $form
             ->schema([
@@ -92,7 +96,7 @@ class BackupResource extends Resource
             ]);
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         /** @var Server $server */
         $server = Filament::getTenant();

--- a/app/Filament/Server/Resources/DatabaseResource.php
+++ b/app/Filament/Server/Resources/DatabaseResource.php
@@ -14,6 +14,7 @@ use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use App\Traits\Filament\CanModifyForm;
 use App\Traits\Filament\CanModifyTable;
+use App\Traits\Filament\HasLimitBadge;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -32,6 +33,7 @@ class DatabaseResource extends Resource
     use CanCustomizeRelations;
     use CanModifyForm;
     use CanModifyTable;
+    use HasLimitBadge;
 
     protected static ?string $model = Database::class;
 
@@ -39,31 +41,20 @@ class DatabaseResource extends Resource
 
     protected static ?string $navigationIcon = 'tabler-database';
 
-    public const WARNING_THRESHOLD = 0.7;
-
-    public static function getNavigationBadge(): string
+    protected static function getBadgeCount(): int
     {
         /** @var Server $server */
         $server = Filament::getTenant();
 
-        $limit = $server->database_limit;
-
-        return $server->databases->count() . ($limit === 0 ? '' : ' / ' . $limit);
+        return $server->databases->count();
     }
 
-    public static function getNavigationBadgeColor(): ?string
+    protected static function getBadgeLimit(): int
     {
         /** @var Server $server */
         $server = Filament::getTenant();
 
-        $limit = $server->database_limit;
-        $count = $server->databases->count();
-
-        if ($limit === 0) {
-            return null;
-        }
-
-        return $count >= $limit ? 'danger' : ($count >= $limit * self::WARNING_THRESHOLD ? 'warning' : 'success');
+        return $server->database_limit;
     }
 
     public static function defaultForm(Form $form): Form

--- a/app/Filament/Server/Resources/DatabaseResource.php
+++ b/app/Filament/Server/Resources/DatabaseResource.php
@@ -12,6 +12,8 @@ use App\Services\Databases\DatabaseManagementService;
 use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -28,6 +30,8 @@ class DatabaseResource extends Resource
     use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
+    use CanModifyTable;
 
     protected static ?string $model = Database::class;
 
@@ -62,7 +66,7 @@ class DatabaseResource extends Resource
         return $count >= $limit ? 'danger' : ($count >= $limit * self::WARNING_THRESHOLD ? 'warning' : 'success');
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         /** @var Server $server */
         $server = Filament::getTenant();
@@ -99,7 +103,7 @@ class DatabaseResource extends Resource
             ]);
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Server/Resources/DatabaseResource.php
+++ b/app/Filament/Server/Resources/DatabaseResource.php
@@ -6,12 +6,17 @@ use App\Filament\Server\Resources\DatabaseResource\Pages;
 use App\Models\Database;
 use App\Models\Permission;
 use App\Models\Server;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
 
 class DatabaseResource extends Resource
 {
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+
     protected static ?string $model = Database::class;
 
     protected static ?int $navigationSort = 6;
@@ -85,7 +90,7 @@ class DatabaseResource extends Resource
         return auth()->user()->can(Permission::ACTION_DATABASE_DELETE, Filament::getTenant());
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListDatabases::route('/'),

--- a/app/Filament/Server/Resources/DatabaseResource.php
+++ b/app/Filament/Server/Resources/DatabaseResource.php
@@ -6,6 +6,7 @@ use App\Filament\Server\Resources\DatabaseResource\Pages;
 use App\Models\Database;
 use App\Models\Permission;
 use App\Models\Server;
+use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class DatabaseResource extends Resource
 {
+    use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
 
@@ -50,19 +52,6 @@ class DatabaseResource extends Resource
         return $count >= $limit
             ? 'danger'
             : ($count >= $limit * self::WARNING_THRESHOLD ? 'warning' : 'success');
-    }
-
-    // TODO: find better way handle server conflict state
-    public static function canAccess(): bool
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if ($server->isInConflictState()) {
-            return false;
-        }
-
-        return parent::canAccess();
     }
 
     public static function canViewAny(): bool

--- a/app/Filament/Server/Resources/FileResource.php
+++ b/app/Filament/Server/Resources/FileResource.php
@@ -6,12 +6,17 @@ use App\Filament\Server\Resources\FileResource\Pages;
 use App\Models\File;
 use App\Models\Permission;
 use App\Models\Server;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
 
 class FileResource extends Resource
 {
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+
     protected static ?string $model = File::class;
 
     protected static ?int $navigationSort = 2;
@@ -51,7 +56,7 @@ class FileResource extends Resource
         return auth()->user()->can(Permission::ACTION_FILE_DELETE, Filament::getTenant());
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'edit' => Pages\EditFiles::route('/edit/{path}'),

--- a/app/Filament/Server/Resources/FileResource.php
+++ b/app/Filament/Server/Resources/FileResource.php
@@ -5,7 +5,7 @@ namespace App\Filament\Server\Resources;
 use App\Filament\Server\Resources\FileResource\Pages;
 use App\Models\File;
 use App\Models\Permission;
-use App\Models\Server;
+use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class FileResource extends Resource
 {
+    use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
 
@@ -22,19 +23,6 @@ class FileResource extends Resource
     protected static ?int $navigationSort = 2;
 
     protected static ?string $navigationIcon = 'tabler-files';
-
-    // TODO: find better way handle server conflict state
-    public static function canAccess(): bool
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if ($server->isInConflictState()) {
-            return false;
-        }
-
-        return parent::canAccess();
-    }
 
     public static function canViewAny(): bool
     {

--- a/app/Filament/Server/Resources/ScheduleResource.php
+++ b/app/Filament/Server/Resources/ScheduleResource.php
@@ -12,6 +12,8 @@ use App\Models\Schedule;
 use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyForm;
+use App\Traits\Filament\CanModifyTable;
 use Carbon\Carbon;
 use Exception;
 use Filament\Facades\Filament;
@@ -40,6 +42,8 @@ class ScheduleResource extends Resource
     use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyForm;
+    use CanModifyTable;
 
     protected static ?string $model = Schedule::class;
 
@@ -67,7 +71,7 @@ class ScheduleResource extends Resource
         return auth()->user()->can(Permission::ACTION_SCHEDULE_DELETE, Filament::getTenant());
     }
 
-    public static function form(Form $form): Form
+    public static function defaultForm(Form $form): Form
     {
         return $form
             ->columns([
@@ -304,7 +308,7 @@ class ScheduleResource extends Resource
             ]);
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         return $table
             ->columns([

--- a/app/Filament/Server/Resources/ScheduleResource.php
+++ b/app/Filament/Server/Resources/ScheduleResource.php
@@ -7,7 +7,7 @@ use App\Filament\Server\Resources\ScheduleResource\RelationManagers\TasksRelatio
 use App\Helpers\Utilities;
 use App\Models\Permission;
 use App\Models\Schedule;
-use App\Models\Server;
+use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Carbon\Carbon;
@@ -29,6 +29,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ScheduleResource extends Resource
 {
+    use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
 
@@ -37,19 +38,6 @@ class ScheduleResource extends Resource
     protected static ?int $navigationSort = 4;
 
     protected static ?string $navigationIcon = 'tabler-clock';
-
-    // TODO: find better way handle server conflict state
-    public static function canAccess(): bool
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if ($server->isInConflictState()) {
-            return false;
-        }
-
-        return parent::canAccess();
-    }
 
     public static function canViewAny(): bool
     {

--- a/app/Filament/Server/Resources/ScheduleResource.php
+++ b/app/Filament/Server/Resources/ScheduleResource.php
@@ -8,6 +8,8 @@ use App\Helpers\Utilities;
 use App\Models\Permission;
 use App\Models\Schedule;
 use App\Models\Server;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
 use Carbon\Carbon;
 use Exception;
 use Filament\Facades\Filament;
@@ -27,6 +29,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class ScheduleResource extends Resource
 {
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+
     protected static ?string $model = Schedule::class;
 
     protected static ?int $navigationSort = 4;
@@ -303,14 +308,14 @@ class ScheduleResource extends Resource
             ]);
     }
 
-    public static function getRelations(): array
+    public static function getDefaultRelations(): array
     {
         return [
             TasksRelationManager::class,
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListSchedules::route('/'),

--- a/app/Filament/Server/Resources/UserResource.php
+++ b/app/Filament/Server/Resources/UserResource.php
@@ -11,6 +11,7 @@ use App\Services\Subusers\SubuserUpdateService;
 use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
@@ -35,6 +36,7 @@ class UserResource extends Resource
     use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
+    use CanModifyTable;
 
     protected static ?string $model = User::class;
 
@@ -72,7 +74,7 @@ class UserResource extends Resource
         return auth()->user()->can(Permission::ACTION_USER_DELETE, Filament::getTenant());
     }
 
-    public static function table(Table $table): Table
+    public static function defaultTable(Table $table): Table
     {
         /** @var Server $server */
         $server = Filament::getTenant();

--- a/app/Filament/Server/Resources/UserResource.php
+++ b/app/Filament/Server/Resources/UserResource.php
@@ -8,6 +8,8 @@ use App\Models\Server;
 use App\Models\User;
 use App\Services\Subusers\SubuserDeletionService;
 use App\Services\Subusers\SubuserUpdateService;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
@@ -29,6 +31,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class UserResource extends Resource
 {
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+
     protected static ?string $model = User::class;
 
     protected static ?int $navigationSort = 5;
@@ -225,7 +230,7 @@ class UserResource extends Resource
             ]);
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListUsers::route('/'),

--- a/app/Filament/Server/Resources/UserResource.php
+++ b/app/Filament/Server/Resources/UserResource.php
@@ -8,6 +8,7 @@ use App\Models\Server;
 use App\Models\User;
 use App\Services\Subusers\SubuserDeletionService;
 use App\Services\Subusers\SubuserUpdateService;
+use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use Filament\Facades\Filament;
@@ -31,6 +32,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class UserResource extends Resource
 {
+    use BlockAccessInConflict;
     use CanCustomizePages;
     use CanCustomizeRelations;
 
@@ -48,19 +50,6 @@ class UserResource extends Resource
         $server = Filament::getTenant();
 
         return (string) $server->subusers->count();
-    }
-
-    // TODO: find better way handle server conflict state
-    public static function canAccess(): bool
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if ($server->isInConflictState()) {
-            return false;
-        }
-
-        return parent::canAccess();
     }
 
     public static function canViewAny(): bool

--- a/app/Filament/Server/Resources/UserResource.php
+++ b/app/Filament/Server/Resources/UserResource.php
@@ -12,6 +12,7 @@ use App\Traits\Filament\BlockAccessInConflict;
 use App\Traits\Filament\CanCustomizePages;
 use App\Traits\Filament\CanCustomizeRelations;
 use App\Traits\Filament\CanModifyTable;
+use App\Traits\Filament\HasLimitBadge;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Actions\Action;
@@ -37,6 +38,7 @@ class UserResource extends Resource
     use CanCustomizePages;
     use CanCustomizeRelations;
     use CanModifyTable;
+    use HasLimitBadge;
 
     protected static ?string $model = User::class;
 
@@ -46,12 +48,12 @@ class UserResource extends Resource
 
     protected static ?string $tenantOwnershipRelationshipName = 'subServers';
 
-    public static function getNavigationBadge(): string
+    protected static function getBadgeCount(): int
     {
         /** @var Server $server */
         $server = Filament::getTenant();
 
-        return (string) $server->subusers->count();
+        return $server->subusers->count();
     }
 
     public static function canViewAny(): bool

--- a/app/Traits/Filament/BlockAccessInConflict.php
+++ b/app/Traits/Filament/BlockAccessInConflict.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Traits\Filament;
+
+use Filament\Facades\Filament;
+
+trait BlockAccessInConflict
+{
+    public static function canAccess(): bool
+    {
+        /** @var Server $server */
+        $server = Filament::getTenant();
+
+        if ($server->isInConflictState()) {
+            return false;
+        }
+
+        return parent::canAccess();
+    }
+}

--- a/app/Traits/Filament/CanCustomizePages.php
+++ b/app/Traits/Filament/CanCustomizePages.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Traits\Filament;
+
+use Filament\Resources\Pages\PageRegistration;
+
+trait CanCustomizePages
+{
+    /** @var array<string, PageRegistration> */
+    protected static array $customPages = [];
+
+    /** @param array<string, PageRegistration> $customPages */
+    public static function registerCustomPages(array $customPages): void
+    {
+        static::$customPages = array_merge(static::$customPages, $customPages);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getDefaultPages(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return array_unique(array_merge(static::getDefaultPages(), static::$customPages), SORT_REGULAR);
+    }
+}

--- a/app/Traits/Filament/CanCustomizeRelations.php
+++ b/app/Traits/Filament/CanCustomizeRelations.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Traits\Filament;
+
+use Filament\Resources\RelationManagers\RelationManager;
+
+trait CanCustomizeRelations
+{
+    /** @var array<class-string<RelationManager>> */
+    protected static array $customRelations = [];
+
+    /** @param class-string<RelationManager>[] $customRelations */
+    public static function registerCustomRelations(string ...$customRelations): void
+    {
+        static::$customRelations = array_merge(static::$customRelations, $customRelations);
+    }
+
+    /**
+     * @return class-string<RelationManager>[]
+     */
+    public static function getDefaultRelations(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return class-string<RelationManager>[]
+     */
+    public static function getRelations(): array
+    {
+        return array_unique(array_merge(static::getDefaultRelations(), static::$customRelations));
+    }
+}

--- a/app/Traits/Filament/CanModifyForm.php
+++ b/app/Traits/Filament/CanModifyForm.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Traits\Filament;
+
+use Closure;
+use Filament\Forms\Form;
+
+trait CanModifyForm
+{
+    /** @var array<Closure> */
+    protected static array $customFormModifications = [];
+
+    public static function modifyForm(Closure $closure): void
+    {
+        static::$customFormModifications[] = $closure;
+    }
+
+    public static function defaultForm(Form $form): Form
+    {
+        return $form;
+    }
+
+    public static function form(Form $form): Form
+    {
+        $form = static::defaultForm($form);
+
+        foreach (static::$customFormModifications as $closure) {
+            $form = $closure($form);
+        }
+
+        return $form;
+    }
+}

--- a/app/Traits/Filament/CanModifyTable.php
+++ b/app/Traits/Filament/CanModifyTable.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Traits\Filament;
+
+use Closure;
+use Filament\Tables\Table;
+
+trait CanModifyTable
+{
+    /** @var array<Closure> */
+    protected static array $customTableModifications = [];
+
+    public static function modifyTable(Closure $closure): void
+    {
+        static::$customTableModifications[] = $closure;
+    }
+
+    public static function defaultTable(Table $table): Table
+    {
+        return $table;
+    }
+
+    public static function table(Table $table): Table
+    {
+        $table = static::defaultTable($table);
+
+        foreach (static::$customTableModifications as $closure) {
+            $table = $closure($table);
+        }
+
+        return $table;
+    }
+}

--- a/app/Traits/Filament/HasLimitBadge.php
+++ b/app/Traits/Filament/HasLimitBadge.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Traits\Filament;
+
+trait HasLimitBadge
+{
+    public const WARNING_THRESHOLD = 0.7;
+
+    protected static function getBadgeCount(): int
+    {
+        return 0;
+    }
+
+    protected static function getBadgeLimit(): int
+    {
+        return 0;
+    }
+
+    public static function getNavigationBadge(): string
+    {
+        $limit = static::getBadgeLimit();
+        $count = static::getBadgeCount();
+
+        return $count . ($limit === 0 ? '' : ' / ' . $limit);
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        $limit = static::getBadgeLimit();
+        $count = static::getBadgeCount();
+
+        if ($limit === 0) {
+            return null;
+        }
+
+        return $count >= $limit ? 'danger' : ($count >= $limit * self::WARNING_THRESHOLD ? 'warning' : 'success');
+    }
+}


### PR DESCRIPTION
Adds new traits to most of our resources to make it possible to customize pages, relations, tables and forms. This can later be used by plugins to extend (and change) our default resources.

I also added a trait that handles the access when the server is in a conflict state and a trait for displaying a count/ limit on the navigation badge.