### PR TITLE
Fix: Search for tags in correct variable

### DIFF
--- a/app/Services/Servers/ServerCreationService.php
+++ b/app/Services/Servers/ServerCreationService.php
@@ -128,7 +128,7 @@ class ServerCreationService
             Arr::get($data, 'memory', 0),
             Arr::get($data, 'disk', 0),
             Arr::get($data, 'cpu', 0),
-            Arr::get($data, 'tags', []),
+            $deployment->getTags(),
         );
 
         return $this->allocationSelectionService->setDedicated($deployment->isDedicated())


### PR DESCRIPTION
Previously creating a server through the api on a specific node wouldn't work with something like this in the payload:

"deploy" => [
            "dedicated_ip" => false,
            "tags" => ["yournodetag"],
            "port_range" => []
        ],
Because the tag would be completely erased by the validator. And would only be stored in the deployment variable.
This will fix that by using the deployment variable instead of the data variable