### PR TITLE
Nullable allocation in server-entry blade

### DIFF
--- a/resources/views/livewire/server-entry.blade.php
+++ b/resources/views/livewire/server-entry.blade.php
@@ -48,7 +48,7 @@
             <div class="hidden sm:block">
                 <p class="text-sm dark:text-gray-400">Network</p>
                 <hr class="p-0.5">
-                <p class="text-md font-semibold">{{ $server->allocation->address }} </p>
+                <p class="text-md font-semibold">{{ $server->allocation?->address }} ?? 'None' </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This original change from #1432 got overwritten by #1470
https://github.com/pelican-dev/panel/blob/dca37ccc95ca6425fcc7613490adf17d17698e97/resources/views/livewire/server-entry.blade.php#L44