### PR TITLE
Filters sensitive credential fields from auth:fail logs

### DIFF
--- a/app/Listeners/Auth/AuthenticationListener.php
+++ b/app/Listeners/Auth/AuthenticationListener.php
@@ -8,6 +8,10 @@ use Illuminate\Auth\Events\Login;
 
 class AuthenticationListener
 {
+    private const PROTECTED_FIELDS = [
+        'password', 'token', 'secret'
+    ];
+
     /**
      * Handles an authentication event by logging the user and information about
      * the request.
@@ -22,7 +26,9 @@ class AuthenticationListener
 
         if ($event instanceof Failed) {
             foreach ($event->credentials as $key => $value) {
-                $activity = $activity->property($key, $value);
+                if (!in_array($key, self::PROTECTED_FIELDS, true)) {
+                    $activity = $activity->property($key, $value);
+                }
             }
         }
 


### PR DESCRIPTION
This patch filters sensitive credential fields during logging, ensuring only safe identifiers (email, username, IP, useragent) are recorded while maintaining the current audit trail functionality. 

I also propose purging auth:fail logs in the next update so that any currently logged data is cleared.