### PR TITLE
api(client): use server condition value for status

### DIFF
--- a/app/Transformers/Api/Client/ServerTransformer.php
+++ b/app/Transformers/Api/Client/ServerTransformer.php
@@ -68,7 +68,7 @@ class ServerTransformer extends BaseClientTransformer
                 'allocations' => $server->allocation_limit,
                 'backups' => $server->backup_limit,
             ],
-            'status' => $server->status,
+            'status' => $server->condition->value,
             // This field is deprecated, please use "status".
             'is_suspended' => $server->isSuspended(),
             // This field is deprecated, please use "status".


### PR DESCRIPTION
api(client): use condition property for server status

Fixes client api, api:client:server.view, by replacing the server status field with the value from the server’s condition property, which was previously always null. Now returns “offline”, “running”, etc.