### PR TITLE
Switch the sub-server File Manager to display more files per page

### DIFF
--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -83,7 +83,7 @@ class ListFiles extends ListRecords
         $files = File::get($server, $this->path);
 
         return $table
-            ->paginated([25, 50])
+            ->paginationPageOptions([25, 50, 100, 150, 200])
             ->defaultPaginationPageOption(25)
             ->query(fn () => $files->orderByDesc('is_directory'))
             ->defaultSort('name')

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -30,7 +30,7 @@ class File extends Model
 {
     use Sushi;
 
-    protected int $sushiInsertChunkSize = 100;
+    protected int $sushiInsertChunkSize = 200;
 
     public const ARCHIVE_MIMES = [
         'application/vnd.rar', // .rar


### PR DESCRIPTION
### Added
- Larger file-manager pagination options (100, 150, 200).

For server that have a large amount of plugins the default values of 25/50 is very annoying to use. No reason to not support larger pagination as the allocation page for the node options supports this. 