### PR TITLE
Move header actions to iconbuttons

### DIFF
--- a/app/Filament/Server/Resources/AllocationResource/Pages/ListAllocations.php
+++ b/app/Filament/Server/Resources/AllocationResource/Pages/ListAllocations.php
@@ -13,6 +13,7 @@ use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Facades\Filament;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\IconSize;
 
 class ListAllocations extends ListRecords
 {
@@ -29,8 +30,10 @@ class ListAllocations extends ListRecords
 
         return [
             Action::make('addAllocation')
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon(fn () => $server->allocations()->count() >= $server->allocation_limit ? 'tabler-network-off' : 'tabler-network')
                 ->authorize(fn () => auth()->user()->can(Permission::ACTION_ALLOCATION_CREATE, $server))
-                ->label(fn () => $server->allocations()->count() >= $server->allocation_limit ? 'Allocation limit reached' : 'Add Allocation')
+                ->tooltip(fn () => $server->allocations()->count() >= $server->allocation_limit ? 'Allocation limit reached' : 'Add Allocation')
                 ->hidden(fn () => !config('panel.client_features.allocations.enabled'))
                 ->disabled(fn () => $server->allocations()->count() >= $server->allocation_limit)
                 ->color(fn () => $server->allocations()->count() >= $server->allocation_limit ? 'danger' : 'primary')

--- a/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/BackupResource/Pages/ListBackups.php
@@ -15,6 +15,7 @@ use Filament\Actions\CreateAction;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\IconSize;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ListBackups extends ListRecords
@@ -33,8 +34,9 @@ class ListBackups extends ListRecords
         return [
             CreateAction::make()
                 ->authorize(fn () => auth()->user()->can(Permission::ACTION_BACKUP_CREATE, $server))
-                ->label(fn () => $server->backups()->count() >= $server->backup_limit ? 'Backup limit reached' : 'Create Backup')
+                ->icon('tabler-file-zip')->iconButton()->iconSize(IconSize::Large)
                 ->disabled(fn () => $server->backups()->count() >= $server->backup_limit)
+                ->tooltip(fn () => $server->backups()->count() >= $server->backup_limit ? 'Backup Limit Reached' : 'Create Backup') // Disabled Buttons have no tooltips in v3 :/
                 ->color(fn () => $server->backups()->count() >= $server->backup_limit ? 'danger' : 'primary')
                 ->createAnother(false)
                 ->action(function (InitiateBackupService $initiateBackupService, $data) use ($server) {

--- a/app/Filament/Server/Resources/DatabaseResource/Pages/ListDatabases.php
+++ b/app/Filament/Server/Resources/DatabaseResource/Pages/ListDatabases.php
@@ -16,6 +16,7 @@ use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\IconSize;
 
 class ListDatabases extends ListRecords
 {
@@ -32,7 +33,9 @@ class ListDatabases extends ListRecords
 
         return [
             CreateAction::make('new')
-                ->label(fn () => $server->databases()->count() >= $server->database_limit ? 'Database limit reached' : 'Create Database')
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon(fn () => $server->databases()->count() >= $server->database_limit ? 'tabler-database-x' : 'tabler-database-plus')
+                ->tooltip(fn () => $server->databases()->count() >= $server->database_limit ? 'Database limit reached' : 'Create Database')
                 ->disabled(fn () => $server->databases()->count() >= $server->database_limit)
                 ->color(fn () => $server->databases()->count() >= $server->database_limit ? 'danger' : 'primary')
                 ->createAnother(false)

--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -31,6 +31,7 @@ use Filament\Notifications\Notification;
 use Filament\Panel;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Resources\Pages\PageRegistration;
+use Filament\Support\Enums\IconSize;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Actions\BulkAction;
@@ -416,9 +417,9 @@ class ListFiles extends ListRecords
         return [
             HeaderAction::make('new_file')
                 ->authorize(fn () => auth()->user()->can(Permission::ACTION_FILE_CREATE, $server))
-                ->label('New File')
-                ->color('gray')
-                ->keyBindings('')
+                ->tooltip('New File')
+                ->hiddenLabel()->icon('tabler-file-plus')->iconButton()->iconSize(IconSize::Large)
+                ->color('primary')
                 ->modalSubmitActionLabel('Create')
                 ->action(function ($data) {
                     $path = join_paths($this->path, $data['name']);
@@ -458,8 +459,9 @@ class ListFiles extends ListRecords
                 ]),
             HeaderAction::make('new_folder')
                 ->authorize(fn () => auth()->user()->can(Permission::ACTION_FILE_CREATE, $server))
-                ->label('New Folder')
-                ->color('gray')
+                ->hiddenLabel()->icon('tabler-folder-plus')->iconButton()->iconSize(IconSize::Large)
+                ->tooltip('New Folder')
+                ->color('primary')
                 ->action(function ($data) {
                     try {
                         $this->getDaemonFileRepository()->createDirectory($data['name'], $this->path);
@@ -485,7 +487,9 @@ class ListFiles extends ListRecords
                 ]),
             HeaderAction::make('upload')
                 ->authorize(fn () => auth()->user()->can(Permission::ACTION_FILE_CREATE, $server))
-                ->label('Upload')
+                ->hiddenLabel()->icon('tabler-upload')->iconButton()->iconSize(IconSize::Large)
+                ->tooltip('Upload')
+                ->color('success')
                 ->action(function ($data) {
                     if (count($data['files']) > 0 && !isset($data['url'])) {
                         /** @var UploadedFile $file */
@@ -534,7 +538,11 @@ class ListFiles extends ListRecords
                 ]),
             HeaderAction::make('search')
                 ->authorize(fn () => auth()->user()->can(Permission::ACTION_FILE_READ, $server))
-                ->label('Global Search')
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->tooltip('Global Search')
+                ->color('primary')
+                ->icon('tabler-world-search')
+                ->modalHeading('Global Search')
                 ->modalSubmitActionLabel('Search')
                 ->form([
                     TextInput::make('searchTerm')

--- a/app/Filament/Server/Resources/ScheduleResource/Pages/EditSchedule.php
+++ b/app/Filament/Server/Resources/ScheduleResource/Pages/EditSchedule.php
@@ -10,6 +10,7 @@ use App\Traits\Filament\CanCustomizeHeaderActions;
 use App\Traits\Filament\CanCustomizeHeaderWidgets;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Enums\IconSize;
 
 class EditSchedule extends EditRecord
 {
@@ -46,14 +47,26 @@ class EditSchedule extends EditRecord
     {
         return [
             Actions\DeleteAction::make()
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-trash')
+                ->tooltip('Delete Schedule')
                 ->after(function ($record) {
                     Activity::event('server:schedule.delete')
                         ->property('name', $record->name)
                         ->log();
                 }),
-            ExportScheduleAction::make(),
-            $this->getSaveFormAction()->formId('form')->label('Save'),
-            $this->getCancelFormAction()->formId('form'),
+            ExportScheduleAction::make()
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-download')
+                ->tooltip('Export Schedule'),
+            $this->getSaveFormAction()->formId('form')
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-device-floppy')
+                ->tooltip('Save Schedule'),
+            $this->getCancelFormAction()->formId('form')
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-cancel')
+                ->tooltip('Cancel'),
         ];
     }
 

--- a/app/Filament/Server/Resources/ScheduleResource/Pages/ListSchedules.php
+++ b/app/Filament/Server/Resources/ScheduleResource/Pages/ListSchedules.php
@@ -10,6 +10,7 @@ use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\IconSize;
 
 class ListSchedules extends ListRecords
 {
@@ -23,8 +24,13 @@ class ListSchedules extends ListRecords
     {
         return [
             CreateAction::make()
-                ->label('New Schedule'),
-            ImportScheduleAction::make(),
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-calendar-plus')
+                ->tooltip('New Schedule'),
+            ImportScheduleAction::make()
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-download')
+                ->tooltip('Import Schedule'),
         ];
     }
 

--- a/app/Filament/Server/Resources/ScheduleResource/Pages/ViewSchedule.php
+++ b/app/Filament/Server/Resources/ScheduleResource/Pages/ViewSchedule.php
@@ -14,6 +14,7 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\EditAction;
 use Filament\Facades\Filament;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Support\Enums\IconSize;
 
 class ViewSchedule extends ViewRecord
 {
@@ -41,7 +42,10 @@ class ViewSchedule extends ViewRecord
 
                     $this->fillForm();
                 }),
-            EditAction::make(),
+            EditAction::make()
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-calendar-code')
+                ->tooltip('Edit Schedule'),
         ];
     }
 

--- a/app/Filament/Server/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Server/Resources/UserResource/Pages/ListUsers.php
@@ -24,6 +24,7 @@ use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Support\Enums\IconSize;
 
 class ListUsers extends ListRecords
 {
@@ -69,7 +70,9 @@ class ListUsers extends ListRecords
 
         return [
             Actions\CreateAction::make('invite')
-                ->label('Invite User')
+                ->hiddenLabel()->iconButton()->iconSize(IconSize::Large)
+                ->icon('tabler-user-plus')
+                ->tooltip('Invite User')
                 ->createAnother(false)
                 ->authorize(fn () => auth()->user()->can(Permission::ACTION_USER_CREATE, $server))
                 ->form([


### PR DESCRIPTION
Played with this in v4, but in v4 they're moved to the toolbar of the tables.

When limits are reached, icons are changed to an "x" variant if available. Unfortunately, disabled iconButtons do not show tooltips like they do in v4. 

<img width="1068" height="318" alt="image" src="https://github.com/user-attachments/assets/41848c63-2054-4f6e-98a4-c12e70f2dceb" />
<img width="1052" height="321" alt="image" src="https://github.com/user-attachments/assets/d963e2db-7f4a-4ba0-bbb6-e9173197cb57" />
<img width="1080" height="236" alt="image" src="https://github.com/user-attachments/assets/3fe8fd3e-8542-47c6-be09-253f4a1e77a8" />
<img width="1049" height="254" alt="image" src="https://github.com/user-attachments/assets/3fb91bbc-6b73-46df-ba16-34f924ca16fe" />
<img width="1069" height="276" alt="image" src="https://github.com/user-attachments/assets/4f7aa099-34a7-4a20-9a1b-bb70d79d2b50" />

