### PR TITLE
Fixes #1542

### DIFF
--- a/app/Extensions/Captcha/Schemas/Turnstile/Component.php
+++ b/app/Extensions/Captcha/Schemas/Turnstile/Component.php
@@ -18,6 +18,8 @@ class Component extends Field
 
         $this->required();
 
-        $this->rule(new Rule());
+        // Remove automatic validation rule to prevent validation during state sync
+        // CAPTCHA validation will be handled manually in the authenticate method
+        // $this->rule(new Rule());
     }
 }

--- a/app/Filament/Pages/Auth/Login.php
+++ b/app/Filament/Pages/Auth/Login.php
@@ -148,6 +148,10 @@ class Login extends BaseLogin
 
     private function getCaptchaComponent(): ?Component
     {
+        if ($this->verifyTwoFactor) {
+            return null;
+        }
+
         return $this->captchaService->getActiveSchema()?->getFormComponent();
     }
 

--- a/resources/views/filament/components/turnstile-captcha.blade.php
+++ b/resources/views/filament/components/turnstile-captcha.blade.php
@@ -25,6 +25,7 @@
 
             resetCaptcha = () => {
                 turnstile.reset($refs.turnstile)
+                $wire.set('{{ $statePath }}', null)
             }
         })()"
     >


### PR DESCRIPTION
disables turnstyle when the user is prompted for 2FA, in order to get to the 2FA prompt the user must pass turnstyle but can not use the same one twice.

Aims to fix #1542 