### PR TITLE
use condition instead of status

### DIFF
--- a/app/Transformers/Api/Application/ServerTransformer.php
+++ b/app/Transformers/Api/Application/ServerTransformer.php
@@ -59,7 +59,7 @@ class ServerTransformer extends BaseTransformer
             'identifier' => $server->uuid_short,
             'name' => $server->name,
             'description' => $server->description,
-            'status' => $server->status,
+            'status' => $server->condition,
             // This field is deprecated, please use "status".
             'suspended' => $server->isSuspended(),
             'limits' => [

--- a/app/Transformers/Api/Client/ServerTransformer.php
+++ b/app/Transformers/Api/Client/ServerTransformer.php
@@ -68,7 +68,7 @@ class ServerTransformer extends BaseClientTransformer
                 'allocations' => $server->allocation_limit,
                 'backups' => $server->backup_limit,
             ],
-            'status' => $server->status,
+            'status' => $server->condition,
             // This field is deprecated, please use "status".
             'is_suspended' => $server->isSuspended(),
             // This field is deprecated, please use "status".


### PR DESCRIPTION
Server status is null most of the time, I think it should use server condition instead.
Honestly, I think it's better if we deprecate status field and add in a condition field instead, but other deprecated comments in the files are saying to use status field.. so...