### PR TITLE
remove maxlength rule from egg variable's default_value field

### DIFF
--- a/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/CreateEgg.php
@@ -207,7 +207,7 @@ class CreateEgg extends CreateRecord
                                             '*' => trans('admin/egg.error_reserved'),
                                         ])
                                         ->required(),
-                                    TextInput::make('default_value')->label(trans('admin/egg.default_value'))->maxLength(255),
+                                    TextInput::make('default_value')->label(trans('admin/egg.default_value')),
                                     Fieldset::make(trans('admin/egg.user_permissions'))
                                         ->schema([
                                             Checkbox::make('user_viewable')->label(trans('admin/egg.viewable')),

--- a/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
+++ b/app/Filament/Admin/Resources/EggResource/Pages/EditEgg.php
@@ -196,7 +196,7 @@ class EditEgg extends EditRecord
                                             '*' => trans('admin/egg.error_reserved'),
                                         ])
                                         ->required(),
-                                    TextInput::make('default_value')->label(trans('admin/egg.default_value'))->maxLength(255),
+                                    TextInput::make('default_value')->label(trans('admin/egg.default_value')),
                                     Fieldset::make(trans('admin/egg.user_permissions'))
                                         ->schema([
                                             Checkbox::make('user_viewable')->label(trans('admin/egg.viewable')),


### PR DESCRIPTION
The default_value field used to be string type in database, however it was changed to text.

[Rust autowipe egg](https://github.com/pelican-eggs/games-steamcmd/blob/main/rust/rust_autowipe/egg-rust-autowipe.json) has a variable which has pretty lengthy default value, it will always throw an error whenever we try to edit the egg due to default_value being limited to 255. 

Also since it's a text type in database, should the input for this field become textarea instead of normal text input?