### PR TITLE
Fixed env parser allowing ' and breaking.

### DIFF
--- a/app/Traits/EnvironmentWriterTrait.php
+++ b/app/Traits/EnvironmentWriterTrait.php
@@ -19,7 +19,6 @@ trait EnvironmentWriterTrait
         foreach ($values as $key => $value) {
             if (preg_match("/'/", $value)) {
                 throw new RuntimeException("$key is invalid.");
-                return;
             }
         }
         Env::writeVariables($values, base_path('.env'), true);

--- a/app/Traits/EnvironmentWriterTrait.php
+++ b/app/Traits/EnvironmentWriterTrait.php
@@ -16,6 +16,12 @@ trait EnvironmentWriterTrait
      */
     public function writeToEnvironment(array $values = []): void
     {
+        foreach ($values as $key => $value) {
+            if (preg_match("/'/", $value)) {
+                throw new RuntimeException("$key is invalid.");
+                return;
+            }
+        }
         Env::writeVariables($values, base_path('.env'), true);
     }
 }


### PR DESCRIPTION
I attempted with both " and ` seems that the only one that broke .env was '.
Let me know if you guys prefer to do it so I can stop trying... 