### PR TITLE
Fix server creation without deployment

### DIFF
--- a/app/Services/Servers/ServerCreationService.php
+++ b/app/Services/Servers/ServerCreationService.php
@@ -39,6 +39,8 @@ class ServerCreationService
      * as possible given the input data. For example, if an allocation_id is passed with
      * no node_id the node_is will be picked from the allocation.
      *
+     * @param  array<mixed, mixed>  $data
+     *
      * @throws \Throwable
      * @throws \App\Exceptions\DisplayException
      * @throws \Illuminate\Validation\ValidationException

--- a/app/Services/Servers/ServerCreationService.php
+++ b/app/Services/Servers/ServerCreationService.php
@@ -39,16 +39,6 @@ class ServerCreationService
      * as possible given the input data. For example, if an allocation_id is passed with
      * no node_id the node_is will be picked from the allocation.
      *
-     * @param array{
-     *     node_id?: int,
-     *     oom_killer?: bool,
-     *     oom_disabled?: bool,
-     *     egg_id?: int,
-     *     image?: ?string,
-     *     startup?: ?string,
-     *     start_on_completion?: ?bool,
-     * } $data
-     *
      * @throws \Throwable
      * @throws \App\Exceptions\DisplayException
      * @throws \Illuminate\Validation\ValidationException
@@ -94,6 +84,8 @@ class ServerCreationService
             if (empty($data['node_id'])) {
                 $data['node_id'] = $nodes->first();
             }
+        } else {
+            $data['node_id'] = Allocation::find($data['allocation_id'])?->node_id;
         }
 
         Assert::false(empty($data['node_id']), 'Expected a non-empty node_id in server creation data.');


### PR DESCRIPTION
When not using deployment, get the `node_id` from the allocation.