### PR TITLE
Auto create missing users when using oauth

### DIFF
--- a/app/Extensions/OAuth/OAuthSchemaInterface.php
+++ b/app/Extensions/OAuth/OAuthSchemaInterface.php
@@ -32,4 +32,6 @@ interface OAuthSchemaInterface
     public function getHexColor(): ?string;
 
     public function isEnabled(): bool;
+
+    public function shouldCreatingMissingUsers(): bool;
 }

--- a/app/Extensions/OAuth/OAuthSchemaInterface.php
+++ b/app/Extensions/OAuth/OAuthSchemaInterface.php
@@ -33,5 +33,5 @@ interface OAuthSchemaInterface
 
     public function isEnabled(): bool;
 
-    public function shouldCreatingMissingUsers(): bool;
+    public function shouldCreateMissingUsers(): bool;
 }

--- a/app/Extensions/OAuth/Schemas/OAuthSchema.php
+++ b/app/Extensions/OAuth/Schemas/OAuthSchema.php
@@ -5,7 +5,9 @@ namespace App\Extensions\OAuth\Schemas;
 use App\Extensions\OAuth\OAuthSchemaInterface;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Wizard\Step;
+use Filament\Forms\Set;
 use Illuminate\Support\Str;
 
 abstract class OAuthSchema implements OAuthSchemaInterface
@@ -53,6 +55,17 @@ abstract class OAuthSchema implements OAuthSchemaInterface
                 ->revealable()
                 ->autocomplete(false)
                 ->default(env("OAUTH_{$id}_CLIENT_SECRET")),
+            Toggle::make("OAUTH_{$id}_SHOULD_CREATE_MISSING_USERS")
+                ->label('Should missing users be automatically created when trying to login?')
+                ->columnSpanFull()
+                ->inline(false)
+                ->onIcon('tabler-check')
+                ->offIcon('tabler-x')
+                ->onColor('success')
+                ->offColor('danger')
+                ->formatStateUsing(fn ($state): bool => (bool) $state)
+                ->afterStateUpdated(fn ($state, Set $set) => $set("OAUTH_{$id}_SHOULD_CREATE_MISSING_USERS", (bool) $state))
+                ->default(env("OAUTH_{$id}_SHOULD_CREATE_MISSING_USERS")),
         ];
     }
 
@@ -95,5 +108,12 @@ abstract class OAuthSchema implements OAuthSchemaInterface
         $id = Str::upper($this->getId());
 
         return env("OAUTH_{$id}_ENABLED", false);
+    }
+
+    public function shouldCreatingMissingUsers(): bool
+    {
+        $id = Str::upper($this->getId());
+
+        return env("OAUTH_{$id}_SHOULD_CREATE_MISSING_USERS", false);
     }
 }

--- a/app/Extensions/OAuth/Schemas/OAuthSchema.php
+++ b/app/Extensions/OAuth/Schemas/OAuthSchema.php
@@ -56,7 +56,7 @@ abstract class OAuthSchema implements OAuthSchemaInterface
                 ->autocomplete(false)
                 ->default(env("OAUTH_{$id}_CLIENT_SECRET")),
             Toggle::make("OAUTH_{$id}_SHOULD_CREATE_MISSING_USERS")
-                ->label('Should missing users be automatically created when trying to login?')
+                ->label(trans('admin/setting.oauth.create_missing_users'))
                 ->columnSpanFull()
                 ->inline(false)
                 ->onIcon('tabler-check')

--- a/app/Extensions/OAuth/Schemas/OAuthSchema.php
+++ b/app/Extensions/OAuth/Schemas/OAuthSchema.php
@@ -110,7 +110,7 @@ abstract class OAuthSchema implements OAuthSchemaInterface
         return env("OAUTH_{$id}_ENABLED", false);
     }
 
-    public function shouldCreatingMissingUsers(): bool
+    public function shouldCreateMissingUsers(): bool
     {
         $id = Str::upper($this->getId());
 

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -12,7 +12,6 @@ use Filament\Notifications\Notification;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Laravel\Socialite\Facades\Socialite;
 
 class OAuthController extends Controller
@@ -92,12 +91,8 @@ class OAuthController extends Controller
             $username = $oauthUser->getNickname();
             $email = $oauthUser->getEmail();
 
-            if (!$username && $email) {
-                $username = str($email)->before('@')->toString() . Str::random(3);
-            }
-
             // Incomplete data, can't create user - redirect to normal login
-            if (!$username && !$email) {
+            if (!$email) {
                 Notification::make()
                     ->title('No linked User found')
                     ->danger()

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -102,15 +102,13 @@ class OAuthController extends Controller
                 return redirect()->route('auth.login');
             }
 
-            $data = [
+            $user = $this->userCreation->handle([
                 'username' => $username,
                 'email' => $email,
                 'oauth' => [
                     $driver->getId() => $oauthUser->getId(),
                 ],
-            ];
-
-            $user = $this->userCreation->handle($data);
+            ]);
         }
 
         $this->auth->guard()->login($user, true);

--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -79,7 +79,7 @@ class OAuthController extends Controller
 
         if (!$user) {
             // No user found and auto creation is disabled - redirect to normal login
-            if (!$driver->shouldCreatingMissingUsers()) {
+            if (!$driver->shouldCreateMissingUsers()) {
                 Notification::make()
                     ->title('No linked User found')
                     ->danger()

--- a/app/Services/Subusers/SubuserCreationService.php
+++ b/app/Services/Subusers/SubuserCreationService.php
@@ -4,7 +4,6 @@ namespace App\Services\Subusers;
 
 use App\Events\Server\SubUserAdded;
 use App\Models\User;
-use Illuminate\Support\Str;
 use App\Models\Server;
 use App\Models\Subuser;
 use Illuminate\Database\ConnectionInterface;
@@ -40,14 +39,8 @@ class SubuserCreationService
         return $this->connection->transaction(function () use ($server, $email, $permissions) {
             $user = User::query()->where('email', $email)->first();
             if (!$user) {
-                // Just cap the username generated at 64 characters at most and then append a random string
-                // to the end to make it "unique"...
-                [$beforeDomain] = explode('@', $email, 1);
-                $username = substr(preg_replace('/([^\w.-]+)/', '', $beforeDomain), 0, 64) . Str::random(3);
-
                 $user = $this->userCreationService->handle([
                     'email' => $email,
-                    'username' => $username,
                     'root_admin' => false,
                 ]);
             }

--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Users;
 
 use App\Models\Role;
+use Illuminate\Support\Str;
 use Ramsey\Uuid\Uuid;
 use App\Models\User;
 use Illuminate\Contracts\Hashing\Hasher;
@@ -41,6 +42,16 @@ class UserCreationService
 
         $isRootAdmin = array_key_exists('root_admin', $data) && $data['root_admin'];
         unset($data['root_admin']);
+
+        if (empty($data['username'])) {
+            $username = str($data['email'])
+                ->before('@')
+                ->replace(['.', '-'], '')
+                ->ascii()
+                ->substr(0, 64);
+
+            $data['username'] = $username->toString() . Str::random(3);
+        }
 
         /** @var User $user */
         $user = User::query()->forceCreate(array_merge($data, [

--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -44,14 +44,14 @@ class UserCreationService
         unset($data['root_admin']);
 
         if (empty($data['username'])) {
-            $username = str($data['email'])
-                ->before('@')
-                ->replace(['.', '-'], '')
-                ->ascii()
-                ->substr(0, 64);
-
-            $data['username'] = $username->toString() . Str::random(3);
+            $data['username'] = str($data['email'])->before('@')->toString() . Str::random(3);
         }
+
+        $data['username'] = str($data['username'])
+            ->replace(['.', '-'], '')
+            ->ascii()
+            ->substr(0, 64)
+            ->toString();
 
         /** @var User $user */
         $user = User::query()->forceCreate(array_merge($data, [

--- a/lang/en/admin/setting.php
+++ b/lang/en/admin/setting.php
@@ -97,6 +97,7 @@ return [
         'base_url' => 'Base URL',
         'display_name' => 'Display Name',
         'auth_url' => 'Authorization callback URL',
+        'create_missing_users' => 'Auto Create Missing Users?',
     ],
     'misc' => [
         'auto_allocation' => [


### PR DESCRIPTION
Adds a new option to all providers to automatically create (& link) missing users. This is turned off by default.
These users will still recieve a "Account created" mail with a password reset link, if they wish to also setup a panel password.

<img width="1439" height="268" alt="grafik" src="https://github.com/user-attachments/assets/4b962aa8-cf07-46af-a0e0-3347f4056cee" />