### PR TITLE
Update egg-vanilla-minecraft.yaml

### DIFF
--- a/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml
+++ b/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml
@@ -1,7 +1,7 @@
 _comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
 meta:
   version: PLCN_v2
-  update_url: 'https://github.com/pelican-dev/panel/raw/main/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.json'
+  update_url: 'https://github.com/pelican-dev/panel/raw/main/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml'
 exported_at: '2025-08-05T20:59:51+00:00'
 name: 'Vanilla Minecraft'
 author: panel@example.com

--- a/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml
+++ b/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml
@@ -1,8 +1,8 @@
 _comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
 meta:
   version: PLCN_v2
-  update_url: 'https://github.com/pelican-dev/panel/raw/main/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml'
-exported_at: '2025-07-25T13:32:13+00:00'
+  update_url: 'https://github.com/pelican-dev/panel/raw/main/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.json'
+exported_at: '2025-08-05T20:59:51+00:00'
 name: 'Vanilla Minecraft'
 author: panel@example.com
 uuid: 9ac39f3d-0c34-4d93-8174-c52ab9e6c57b
@@ -30,6 +30,7 @@ config:
     server.properties:
       parser: properties
       find:
+        server-ip: ''
         server-port: '{{server.allocations.default.port}}'
         query.port: '{{server.allocations.default.port}}'
   startup:

--- a/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml
+++ b/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml
@@ -30,7 +30,6 @@ config:
     server.properties:
       parser: properties
       find:
-        server-ip: 0.0.0.0
         server-port: '{{server.allocations.default.port}}'
         query.port: '{{server.allocations.default.port}}'
   startup:


### PR DESCRIPTION
Added ipv6 support by removing the ip lock to ipv4 anycast.

Removed the 0.0.0.0 server-ip entry

It is also recommended to be empty
https://minecraft.wiki/w/Server.properties