### PR TITLE
Add abstract base class for panel providers

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,45 +2,21 @@
 
 namespace App\Providers\Filament;
 
-use App\Filament\Pages\Auth\Login;
 use App\Filament\Pages\Auth\EditProfile;
-use App\Http\Middleware\LanguageMiddleware;
-use App\Http\Middleware\RequireTwoFactorAuthentication;
-use Filament\Http\Middleware\Authenticate;
-use Filament\Http\Middleware\DisableBladeIconComponents;
-use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\MenuItem;
 use Filament\Navigation\NavigationGroup;
 use Filament\Panel;
-use Filament\PanelProvider;
-use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
-use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Routing\Middleware\SubstituteBindings;
-use Illuminate\Session\Middleware\AuthenticateSession;
-use Illuminate\Session\Middleware\StartSession;
-use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class AdminPanelProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
     {
-        return $panel
-            ->default()
+        return parent::panel($panel)
             ->id('admin')
             ->path('admin')
             ->homeUrl('/')
-            ->spa()
-            ->databaseNotifications()
             ->breadcrumbs(false)
-            ->brandName(config('app.name', 'Pelican'))
-            ->brandLogo(config('app.logo'))
-            ->brandLogoHeight('2rem')
-            ->favicon(config('app.favicon', '/pelican.ico'))
-            ->topNavigation(fn () => auth()->user()->getCustomization()['top_navigation'] ?? false)
-            ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
-            ->login(Login::class)
-            ->passwordReset()
+            ->sidebarCollapsibleOnDesktop()
             ->userMenuItems([
                 'profile' => MenuItem::make()
                     ->label(fn () => trans('filament-panels::pages/auth/edit-profile.label'))
@@ -58,25 +34,8 @@ class AdminPanelProvider extends PanelProvider
                     ->collapsible(false),
                 NavigationGroup::make(fn () => trans('admin/dashboard.advanced')),
             ])
-            ->sidebarCollapsibleOnDesktop()
             ->discoverResources(in: app_path('Filament/Admin/Resources'), for: 'App\\Filament\\Admin\\Resources')
             ->discoverPages(in: app_path('Filament/Admin/Pages'), for: 'App\\Filament\\Admin\\Pages')
-            ->discoverWidgets(in: app_path('Filament/Admin/Widgets'), for: 'App\\Filament\\Admin\\Widgets')
-            ->middleware([
-                EncryptCookies::class,
-                AddQueuedCookiesToResponse::class,
-                StartSession::class,
-                AuthenticateSession::class,
-                ShareErrorsFromSession::class,
-                VerifyCsrfToken::class,
-                SubstituteBindings::class,
-                DisableBladeIconComponents::class,
-                DispatchServingFilamentEvent::class,
-                LanguageMiddleware::class,
-                RequireTwoFactorAuthentication::class,
-            ])
-            ->authMiddleware([
-                Authenticate::class,
-            ]);
+            ->discoverWidgets(in: app_path('Filament/Admin/Widgets'), for: 'App\\Filament\\Admin\\Widgets');
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -2,68 +2,27 @@
 
 namespace App\Providers\Filament;
 
-use App\Filament\Pages\Auth\Login;
-use App\Filament\Pages\Auth\EditProfile;
-use App\Http\Middleware\LanguageMiddleware;
-use App\Http\Middleware\RequireTwoFactorAuthentication;
 use Filament\Facades\Filament;
-use Filament\Http\Middleware\Authenticate;
-use Filament\Http\Middleware\DisableBladeIconComponents;
-use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\MenuItem;
 use Filament\Panel;
-use Filament\PanelProvider;
-use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
-use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Routing\Middleware\SubstituteBindings;
-use Illuminate\Session\Middleware\AuthenticateSession;
-use Illuminate\Session\Middleware\StartSession;
-use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class AppPanelProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
     {
-        return $panel
+        return parent::panel($panel)
             ->id('app')
-            ->spa()
-            ->databaseNotifications()
+            ->default()
             ->breadcrumbs(false)
-            ->brandName(config('app.name', 'Pelican'))
-            ->brandLogo(config('app.logo'))
-            ->brandLogoHeight('2rem')
-            ->favicon(config('app.favicon', '/pelican.ico'))
-            ->topNavigation(fn () => auth()->user()->getCustomization()['top_navigation'] ?? false)
-            ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
             ->navigation(false)
-            ->profile(EditProfile::class, false)
-            ->login(Login::class)
-            ->passwordReset()
             ->userMenuItems([
                 MenuItem::make()
                     ->label(trans('profile.admin'))
                     ->url('/admin')
                     ->icon('tabler-arrow-forward')
                     ->sort(5)
-                    ->visible(fn (): bool => auth()->user()->canAccessPanel(Filament::getPanel('admin'))),
+                    ->visible(fn () => auth()->user()->canAccessPanel(Filament::getPanel('admin'))),
             ])
-            ->discoverResources(in: app_path('Filament/App/Resources'), for: 'App\\Filament\\App\\Resources')
-            ->middleware([
-                EncryptCookies::class,
-                AddQueuedCookiesToResponse::class,
-                StartSession::class,
-                AuthenticateSession::class,
-                ShareErrorsFromSession::class,
-                VerifyCsrfToken::class,
-                SubstituteBindings::class,
-                DisableBladeIconComponents::class,
-                DispatchServingFilamentEvent::class,
-                LanguageMiddleware::class,
-                RequireTwoFactorAuthentication::class,
-            ])
-            ->authMiddleware([
-                Authenticate::class,
-            ]);
+            ->discoverResources(in: app_path('Filament/App/Resources'), for: 'App\\Filament\\App\\Resources');
     }
 }

--- a/app/Providers/Filament/PanelProvider.php
+++ b/app/Providers/Filament/PanelProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Providers\Filament;
+
+use App\Filament\Pages\Auth\Login;
+use App\Filament\Pages\Auth\EditProfile;
+use App\Http\Middleware\LanguageMiddleware;
+use App\Http\Middleware\RequireTwoFactorAuthentication;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Panel;
+use Filament\PanelProvider as BasePanelProvider;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+abstract class PanelProvider extends BasePanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->spa()
+            ->databaseNotifications()
+            ->brandName(config('app.name', 'Pelican'))
+            ->brandLogo(config('app.logo'))
+            ->brandLogoHeight('2rem')
+            ->favicon(config('app.favicon', '/pelican.ico'))
+            ->topNavigation(fn () => auth()->user()->getCustomization()['top_navigation'] ?? false)
+            ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
+            ->profile(EditProfile::class, false)
+            ->login(Login::class)
+            ->passwordReset()
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+                LanguageMiddleware::class,
+                RequireTwoFactorAuthentication::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/app/Providers/Filament/ServerPanelProvider.php
+++ b/app/Providers/Filament/ServerPanelProvider.php
@@ -3,48 +3,24 @@
 namespace App\Providers\Filament;
 
 use App\Filament\App\Resources\ServerResource\Pages\ListServers;
-use App\Filament\Pages\Auth\Login;
 use App\Filament\Admin\Resources\ServerResource\Pages\EditServer;
 use App\Filament\Pages\Auth\EditProfile;
 use App\Http\Middleware\Activity\ServerSubject;
-use App\Http\Middleware\LanguageMiddleware;
-use App\Http\Middleware\RequireTwoFactorAuthentication;
 use App\Models\Server;
 use Filament\Facades\Filament;
-use Filament\Http\Middleware\Authenticate;
-use Filament\Http\Middleware\DisableBladeIconComponents;
-use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\MenuItem;
 use Filament\Navigation\NavigationItem;
 use Filament\Panel;
-use Filament\PanelProvider;
-use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
-use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Routing\Middleware\SubstituteBindings;
-use Illuminate\Session\Middleware\AuthenticateSession;
-use Illuminate\Session\Middleware\StartSession;
-use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class ServerPanelProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
     {
-        return $panel
+        return parent::panel($panel)
             ->id('server')
             ->path('server')
             ->homeUrl('/')
-            ->spa()
-            ->databaseNotifications()
             ->tenant(Server::class)
-            ->brandName(config('app.name', 'Pelican'))
-            ->brandLogo(config('app.logo'))
-            ->brandLogoHeight('2rem')
-            ->favicon(config('app.favicon', '/pelican.ico'))
-            ->topNavigation(fn () => auth()->user()->getCustomization()['top_navigation'] ?? false)
-            ->maxContentWidth(config('panel.filament.display-width', 'screen-2xl'))
-            ->login(Login::class)
-            ->passwordReset()
             ->userMenuItems([
                 'profile' => MenuItem::make()
                     ->label(fn () => trans('filament-panels::pages/auth/edit-profile.label'))
@@ -59,7 +35,7 @@ class ServerPanelProvider extends PanelProvider
                     ->icon('tabler-arrow-forward')
                     ->url(fn () => Filament::getPanel('admin')->getUrl())
                     ->sort(5)
-                    ->visible(fn (): bool => auth()->user()->canAccessPanel(Filament::getPanel('admin'))),
+                    ->visible(fn () => auth()->user()->canAccessPanel(Filament::getPanel('admin'))),
             ])
             ->navigationItems([
                 NavigationItem::make(trans('server/console.open_in_admin'))
@@ -72,21 +48,7 @@ class ServerPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Server/Pages'), for: 'App\\Filament\\Server\\Pages')
             ->discoverWidgets(in: app_path('Filament/Server/Widgets'), for: 'App\\Filament\\Server\\Widgets')
             ->middleware([
-                EncryptCookies::class,
-                AddQueuedCookiesToResponse::class,
-                StartSession::class,
-                AuthenticateSession::class,
-                ShareErrorsFromSession::class,
-                VerifyCsrfToken::class,
-                SubstituteBindings::class,
-                DisableBladeIconComponents::class,
-                DispatchServingFilamentEvent::class,
-                LanguageMiddleware::class,
-                RequireTwoFactorAuthentication::class,
                 ServerSubject::class,
-            ])
-            ->authMiddleware([
-                Authenticate::class,
             ]);
     }
 }


### PR DESCRIPTION
Use an abstract base class for our panel providers to reduce duplicate code.
Also make the `app` panel the default one rather than the `admin` panel.