### PR TITLE
Fix auto deploy docker command not including the container argument

### DIFF
--- a/app/Services/Nodes/NodeAutoDeployService.php
+++ b/app/Services/Nodes/NodeAutoDeployService.php
@@ -49,7 +49,7 @@ class NodeAutoDeployService
 
         return sprintf(
             '%s wings configure --panel-url %s --token %s --node %d%s',
-            $docker ? 'docker compose exec -it' : 'sudo',
+            $docker ? 'docker compose exec -it wings' : 'sudo',
             config('app.url'),
             $token,
             $node->id,


### PR DESCRIPTION
docker exec -it requires the container as the argument, which currently the command doesn't pass so it gets parsed as: docker exec configure ... in container wings, rather then docker exec wings configure ... in container wings.