### PR TITLE
Fix container status caching

### DIFF
--- a/app/Http/Controllers/Api/Remote/Servers/ServerContainersController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerContainersController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Remote\Servers;
 
+use App\Enums\ContainerStatus;
 use App\Http\Requests\Api\Remote\ServerRequest;
 use App\Models\Server;
 use Illuminate\Http\JsonResponse;
@@ -14,7 +15,7 @@ class ServerContainersController extends Controller
      */
     public function status(ServerRequest $request, Server $server): JsonResponse
     {
-        $status = fluent($request->json()->all())->get('data.new_state');
+        $status = ContainerStatus::tryFrom($request->json('data.new_state')) ?? ContainerStatus::Missing;
 
         cache()->put("servers.$server->uuid.status", $status, now()->addHour());
 


### PR DESCRIPTION
Fixes `Return value must be of type ContainerStatus, string returned` errors.