### PR TITLE
fix: Wrong conversion if decimal prefix selected

### DIFF
--- a/app/Filament/Server/Widgets/ServerOverview.php
+++ b/app/Filament/Server/Widgets/ServerOverview.php
@@ -68,7 +68,7 @@ class ServerOverview extends StatsOverviewWidget
         }
 
         $latestMemoryUsed = collect(cache()->get("servers.{$this->server->id}.memory_bytes"))->last(default: 0);
-        $totalMemory = $this->server->memory * (config('panel.use_binary_prefix') ? 2 ** 20 : 1000 * 1000);
+        $totalMemory = $this->server->memory * (config('panel.use_binary_prefix') ? 1024 * 1024 : 1000 * 1000);
 
         $used = convert_bytes_to_readable($latestMemoryUsed);
         $total = convert_bytes_to_readable($totalMemory);

--- a/app/Filament/Server/Widgets/ServerOverview.php
+++ b/app/Filament/Server/Widgets/ServerOverview.php
@@ -68,7 +68,7 @@ class ServerOverview extends StatsOverviewWidget
         }
 
         $latestMemoryUsed = collect(cache()->get("servers.{$this->server->id}.memory_bytes"))->last(default: 0);
-        $totalMemory = $this->server->memory * 2 ** 20;
+        $totalMemory = $this->server->memory * (config('panel.use_binary_prefix') ? 2 ** 20 : 1000 * 1000);
 
         $used = convert_bytes_to_readable($latestMemoryUsed);
         $total = convert_bytes_to_readable($totalMemory);


### PR DESCRIPTION
When using the decimal prefix and setting 16 GB of RAM, the panel displayed 16.79 GB (without overhead) instead of 16 GB (without overhead).
This was due to the using of a binary multiplier (`2^20`), which is only correct for MiB/GiB.

So I've used the `config('panel.use_binary_prefix')` to check what multiplier should be used.


This is a visual fix, but I think it's better like that.
