### PR TITLE
Rename api key prefixes for better clarity

### DIFF
--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -216,7 +216,7 @@ class ApiKey extends PersonalAccessToken
     {
         Assert::oneOf($type, [self::TYPE_ACCOUNT, self::TYPE_APPLICATION]);
 
-        return $type === self::TYPE_ACCOUNT ? 'plcn_' : 'peli_';
+        return $type === self::TYPE_ACCOUNT ? 'pacc_' : 'papp_';
     }
 
     /**


### PR DESCRIPTION
_This does not change existing api keys are any way._