### PR TITLE
Encode file path in url for folders

### DIFF
--- a/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/FileResource/Pages/ListFiles.php
@@ -107,7 +107,7 @@ class ListFiles extends ListRecords
             ])
             ->recordUrl(function (File $file) use ($server) {
                 if ($file->is_directory) {
-                    return self::getUrl(['path' => join_paths($this->path, $file->name)]);
+                    return self::getUrl(['path' => encode_path(join_paths($this->path, $file->name))]);
                 }
 
                 if (!auth()->user()->can(Permission::ACTION_FILE_READ_CONTENT, $server)) {


### PR DESCRIPTION
Rabbit was right... I should apply it for folders as-well
