### PR TITLE
Fix Docker versioning 

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -134,6 +134,16 @@ jobs:
           docker push localhost:5000/base-php:arm64
           rm base-php-arm64.tar base-php-amd64.tar
           
+      - name: Update version in config/app.php (tag)
+        if: "github.event_name == 'release' && github.event.action == 'published'"
+        run: |
+          sed -i "s/'version' => 'canary',/'version' => '${{ steps.build_info.outputs.version_tag }}',/" config/app.php
+          
+      - name: Update version in config/app.php (main)
+        if: "github.event_name == 'push' && contains(github.ref, 'main')"
+        run: |
+          sed -i "s/'version' => 'canary',/'version' => 'dev-${{ steps.build_info.outputs.short_sha }}',/" config/app.php
+          
       - name: Build and Push (tag)
         uses: docker/build-push-action@v6
         if: "github.event_name == 'release' && github.event.action == 'published'"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -138,12 +138,7 @@ jobs:
         if: "github.event_name == 'release' && github.event.action == 'published'"
         run: |
           sed -i "s/'version' => 'canary',/'version' => '${{ steps.build_info.outputs.version_tag }}',/" config/app.php
-          
-      - name: Update version in config/app.php (main)
-        if: "github.event_name == 'push' && contains(github.ref, 'main')"
-        run: |
-          sed -i "s/'version' => 'canary',/'version' => 'dev-${{ steps.build_info.outputs.short_sha }}',/" config/app.php
-          
+              
       - name: Build and Push (tag)
         uses: docker/build-push-action@v6
         if: "github.event_name == 'release' && github.event.action == 'published'"


### PR DESCRIPTION
here is the workflow fix for the docker version of the panel.

you can use my image for testing the image and workflow ghcr.io/nerdscorp/panel:latest

this will use the Release name and update the version from canary to whatever the release name is. i set up the newest relese using this as well as a fake one seen below.

<img width="872" height="724" alt="image" src="https://github.com/user-attachments/assets/3b1d3d34-1ff0-4c58-947e-86d59a8e42a5" />
