### PR TITLE
Only disable "delete backup" when backup hasn't failed

### DIFF
--- a/app/Filament/Server/Resources/Backups/BackupResource.php
+++ b/app/Filament/Server/Resources/Backups/BackupResource.php
@@ -227,7 +227,7 @@ class BackupResource extends Resource
                         ->visible(fn (Backup $backup) => $backup->status === BackupStatus::Successful),
                     DeleteAction::make('delete')
                         ->iconSize(IconSize::Large)
-                        ->disabled(fn (Backup $backup) => $backup->is_locked)
+                        ->disabled(fn (Backup $backup) => $backup->is_locked && $backup->status !== BackupStatus::Failed)
                         ->modalDescription(fn (Backup $backup) => trans('server/backup.actions.delete.description', ['backup' => $backup->name]))
                         ->modalSubmitActionLabel(trans('server/backup.actions.delete.title'))
                         ->action(function (Backup $backup, DeleteBackupService $deleteBackupService) {


### PR DESCRIPTION
Currently, if a failed is locked there is no way to unlock or delete it. This makes a failed backup deletable, even if it's locked.