### PR TITLE
Fix server owner permissions

### DIFF
--- a/app/Services/Servers/GetUserPermissionsService.php
+++ b/app/Services/Servers/GetUserPermissionsService.php
@@ -20,7 +20,7 @@ class GetUserPermissionsService
         if ($user->id === $server->owner_id) {
             return ['*'];
         }
-        
+
         if ($user->isAdmin() && ($user->can('view', $server) || $user->can('update', $server))) {
             $permissions = $user->can('update', $server) ? ['*'] : ['websocket.connect', 'backup.read'];
 


### PR DESCRIPTION
I have stumbled upon a possible bug Server owner cannot start/restart/stop their own server if they have assigned some admin role without server update permission. I would expect that being a server owner would allow you to do anything with the server.

I am not sure if this is just a bug or if it is intentional. I have not read most of the codebase so I do not know if this change has some unwanted behaviour.