### PR TITLE
Fix powerActions visible while loading

### DIFF
--- a/app/Filament/App/Resources/Servers/Pages/ListServers.php
+++ b/app/Filament/App/Resources/Servers/Pages/ListServers.php
@@ -112,7 +112,7 @@ class ListServers extends ListRecords
             ->poll('15s')
             ->columns($usingGrid ? $this->gridColumns() : $this->tableColumns())
             ->recordUrl(!$usingGrid ? (fn (Server $server) => Console::getUrl(panel: 'server', tenant: $server)) : null)
-            ->recordActions(!$usingGrid ? ActionGroup::make(static::getPowerActions(view: 'table')) : [])
+            ->recordActions(!$usingGrid ? static::getPowerActionGroup() : [])
             ->recordActionsAlignment(Alignment::Center->value)
             ->contentGrid($usingGrid ? ['default' => 1, 'md' => 2] : null)
             ->emptyStateIcon('tabler-brand-docker')
@@ -225,10 +225,9 @@ class ListServers extends ListRecords
         }
     }
 
-    /** @return Action[]|ActionGroup[] */
-    public static function getPowerActions(string $view): array
+    public static function getPowerActionGroup(): ActionGroup
     {
-        $actions = [
+        return ActionGroup::make([
             Action::make('start')
                 ->color('primary')
                 ->icon('tabler-player-play-filled')
@@ -254,18 +253,10 @@ class ListServers extends ListRecords
                 ->authorize(fn (Server $server) => auth()->user()->can(Permission::ACTION_CONTROL_STOP, $server))
                 ->visible(fn (Server $server) => !$server->isInConflictState() & $server->retrieveStatus()->isKillable())
                 ->dispatch('powerAction', fn (Server $server) => ['server' => $server, 'action' => 'kill']),
-        ];
-
-        if ($view === 'table') {
-            return $actions;
-        } else {
-            return [
-                ActionGroup::make($actions)
-                    ->icon('tabler-power')
-                    ->color('primary')
-                    ->tooltip('Power Actions')
-                    ->iconSize(IconSize::Large),
-            ];
-        }
+        ])
+            ->icon('tabler-power')
+            ->color('primary')
+            ->tooltip(trans('server/dashboard.power_actions'))
+            ->iconSize(IconSize::Large);
     }
 }

--- a/resources/views/livewire/server-entry.blade.php
+++ b/resources/views/livewire/server-entry.blade.php
@@ -1,3 +1,7 @@
+@php
+    $actiongroup = \App\Filament\App\Resources\Servers\Pages\ListServers::getPowerActionGroup()->record($server);
+@endphp
+
 <div wire:poll.15s
      class="relative cursor-pointer"
      x-on:click="window.location.href = '{{ \App\Filament\Server\Pages\Console::getUrl(panel: 'server', tenant: $server) }}'">
@@ -20,13 +24,11 @@
                     ({{ $server->formatResource(\App\Enums\ServerResourceType::Uptime) }})
                 </span>
             </h2>
-            <div class="end-0" x-on:click.stop>
-                <div class="flex-1 dark:bg-gray-800 dark:text-white rounded-b-lg overflow-hidden p-1">
-                    @foreach (\App\Filament\App\Resources\Servers\Pages\ListServers::getPowerActions(view: 'grid') as $action)
-                        {{ $action->record($server) }}
-                    @endforeach
+            @if ($actiongroup->isVisible())
+                <div class="end-0 flex-1 dark:bg-gray-800 dark:text-white rounded-b-lg overflow-hidden p-1" x-on:click.stop>
+                    {{ $actiongroup }}
                 </div>
-            </div>
+            @endif
         </div>
 
         <div class="flex justify-between text-center items-center gap-4">


### PR DESCRIPTION
Grid
<img width="633" height="155" alt="image" src="https://github.com/user-attachments/assets/a16bdf96-1f68-45bc-b09a-ffbb1edd4eb2" />
<img width="634" height="152" alt="image" src="https://github.com/user-attachments/assets/70c0f1f2-ee71-4495-b2db-4f767e16ae45" />

Table
<img width="1319" height="144" alt="image" src="https://github.com/user-attachments/assets/e396c35f-d04c-4663-b3ed-1f97719d9014" />
<img width="1320" height="163" alt="image" src="https://github.com/user-attachments/assets/0c4d8aeb-06af-46dd-a622-7f9d6dde8546" />

- Both views use ActionGroup
- Use translation for 'Power Actions'