### PR TITLE
Fix `join_paths` for absolute linux paths

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -52,7 +52,7 @@ if (!function_exists('convert_bytes_to_readable')) {
 if (!function_exists('join_paths')) {
     function join_paths(string $base, string ...$paths): string
     {
-        $base = trim($base, '/');
+        $base = rtrim($base, '/');
 
         $paths = array_map(fn (string $path) => trim($path, '/'), $paths);
         $paths = array_filter($paths, fn (string $path) => strlen($path) > 0);


### PR DESCRIPTION
Only trim `/` at the end of the base to make sure absolute linux paths stay correct, e.g. `join_paths(base_path(), 'test')`.