### PR TITLE
Make tests fail-fast & common env

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     name: UI
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         node-version: [20, 22]
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,75 @@ on:
       - main
   pull_request:
 
+env:
+  APP_ENV: testing
+  APP_DEBUG: "false"
+  APP_KEY: ThisIsARandomStringForTests12345
+  APP_TIMEZONE: UTC
+  APP_URL: http://localhost/
+  CACHE_DRIVER: array
+  MAIL_MAILER: array
+  SESSION_DRIVER: array
+  QUEUE_CONNECTION: sync
+  GUZZLE_TIMEOUT: 60
+  GUZZLE_CONNECT_TIMEOUT: 60
+
 jobs:
+  sqlite:
+    name: SQLite
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.3, 8.4]
+    env:
+      DB_CONNECTION: sqlite
+      DB_DATABASE: testing.sqlite
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v4
+
+      - name: Get cache directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.php }}-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: bcmath, curl, gd, mbstring, mysql, openssl, pdo, tokenizer, xml, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-suggest --no-progress --no-scripts
+
+      - name: Create SQLite file
+        run: touch database/testing.sqlite
+
+      - name: Unit tests
+        run: vendor/bin/pest tests/Unit
+        env:
+          DB_HOST: UNIT_NO_DB
+          SKIP_MIGRATIONS: true
+
+      - name: Integration tests
+        run: vendor/bin/pest tests/Integration
+
   mysql:
     name: MySQL
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4]
         database: ["mysql:8"]
@@ -25,21 +88,10 @@ jobs:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     env:
-      APP_ENV: testing
-      APP_DEBUG: "false"
-      APP_KEY: ThisIsARandomStringForTests12345
-      APP_TIMEZONE: UTC
-      APP_URL: http://localhost/
-      CACHE_DRIVER: array
-      MAIL_MAILER: array
-      SESSION_DRIVER: array
-      QUEUE_CONNECTION: sync
       DB_CONNECTION: mysql
       DB_HOST: 127.0.0.1
       DB_DATABASE: testing
       DB_USERNAME: root
-      GUZZLE_TIMEOUT: 60
-      GUZZLE_CONNECT_TIMEOUT: 60
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4
@@ -84,7 +136,7 @@ jobs:
     name: MariaDB
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4]
         database: ["mariadb:10.6", "mariadb:10.11", "mariadb:11.4"]
@@ -98,21 +150,10 @@ jobs:
           - 3306
         options: --health-cmd="mariadb-admin ping || mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     env:
-      APP_ENV: testing
-      APP_DEBUG: "false"
-      APP_KEY: ThisIsARandomStringForTests12345
-      APP_TIMEZONE: UTC
-      APP_URL: http://localhost/
-      CACHE_DRIVER: array
-      MAIL_MAILER: array
-      SESSION_DRIVER: array
-      QUEUE_CONNECTION: sync
       DB_CONNECTION: mariadb
       DB_HOST: 127.0.0.1
       DB_DATABASE: testing
       DB_USERNAME: root
-      GUZZLE_TIMEOUT: 60
-      GUZZLE_CONNECT_TIMEOUT: 60
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4
@@ -153,72 +194,11 @@ jobs:
           DB_PORT: ${{ job.services.database.ports[3306] }}
           DB_USERNAME: root
 
-  sqlite:
-    name: SQLite
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [8.2, 8.3, 8.4]
-    env:
-      APP_ENV: testing
-      APP_DEBUG: "false"
-      APP_KEY: ThisIsARandomStringForTests12345
-      APP_TIMEZONE: UTC
-      APP_URL: http://localhost/
-      CACHE_DRIVER: array
-      MAIL_MAILER: array
-      SESSION_DRIVER: array
-      QUEUE_CONNECTION: sync
-      DB_CONNECTION: sqlite
-      DB_DATABASE: testing.sqlite
-      GUZZLE_TIMEOUT: 60
-      GUZZLE_CONNECT_TIMEOUT: 60
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v4
-
-      - name: Get cache directory
-        id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-${{ matrix.php }}-
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: bcmath, curl, gd, mbstring, mysql, openssl, pdo, tokenizer, xml, zip
-          tools: composer:v2
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-suggest --no-progress --no-scripts
-
-      - name: Create SQLite file
-        run: touch database/testing.sqlite
-
-      - name: Unit tests
-        run: vendor/bin/pest tests/Unit
-        env:
-          DB_HOST: UNIT_NO_DB
-          SKIP_MIGRATIONS: true
-
-      - name: Integration tests
-        run: vendor/bin/pest tests/Integration
-
   postgresql:
     name: PostgreSQL
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4]
         database: ["postgres:14"]
@@ -238,22 +218,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      APP_ENV: testing
-      APP_DEBUG: "false"
-      APP_KEY: ThisIsARandomStringForTests12345
-      APP_TIMEZONE: UTC
-      APP_URL: http://localhost/
-      CACHE_DRIVER: array
-      MAIL_MAILER: array
-      SESSION_DRIVER: array
-      QUEUE_CONNECTION: sync
       DB_CONNECTION: pgsql
       DB_HOST: 127.0.0.1
       DB_DATABASE: testing
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      GUZZLE_TIMEOUT: 60
-      GUZZLE_CONNECT_TIMEOUT: 60
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,8 +66,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
     # Start a temp local registry because workflow can not pull from localy loaded images
     services:
       registry:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php: [ 8.2, 8.3, 8.4 ]
     steps:


### PR DESCRIPTION
We don't need to bloat github workers with full matrix tests when either of them failed.
Also used a common env and overwritting required keys instead of duplicating them.