### PR TITLE
Fix mime type for jar files

### DIFF
--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -175,7 +175,7 @@ class File extends Model
                     'is_directory' => $file['directory'],
                     'is_file' => $file['file'],
                     'is_symlink' => $file['symlink'],
-                    'mime_type' => $file['mime'],
+                    'mime_type' => $file['file'] && str($file['name'])->endsWith('.jar') && in_array($file['mime'], self::ARCHIVE_MIMES) ? 'application/jar' : $file['mime'],
                 ];
             }, $contents);
 

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -175,7 +175,7 @@ class File extends Model
                     'is_directory' => $file['directory'],
                     'is_file' => $file['file'],
                     'is_symlink' => $file['symlink'],
-                    'mime_type' => $file['file'] && str($file['name'])->endsWith('.jar') && in_array($file['mime'], self::ARCHIVE_MIMES) ? 'application/jar' : $file['mime'],
+                    'mime_type' => $file['file'] && str($file['name'])->lower()->endsWith('.jar') && in_array($file['mime'], self::ARCHIVE_MIMES) ? 'application/jar' : $file['mime'],
                 ];
             }, $contents);
 


### PR DESCRIPTION
Closes #1755

If the file name ends with `.jar` but the mime type is an archive (e.g. a zip) change the mime type to `application/jar`.