### PR TITLE
Use `tenantMiddleware` instead of manually fetching `tenant` query param

### DIFF
--- a/app/Http/Middleware/Activity/ServerSubject.php
+++ b/app/Http/Middleware/Activity/ServerSubject.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware\Activity;
 use App\Facades\LogTarget;
 use App\Models\Server;
 use Closure;
+use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,10 +22,7 @@ class ServerSubject
     public function handle(Request $request, Closure $next): Response
     {
         $server = $request->route()->parameter('server');
-
-        if ($request->route()->hasParameter('tenant')) {
-            $server = Server::find($request->route()->parameter('tenant'));
-        }
+        $server ??= Filament::getTenant();
 
         if ($server instanceof Server) {
             LogTarget::setActor($request->user());

--- a/app/Providers/Filament/ServerPanelProvider.php
+++ b/app/Providers/Filament/ServerPanelProvider.php
@@ -41,7 +41,7 @@ class ServerPanelProvider extends PanelProvider
             ->discoverResources(in: app_path('Filament/Server/Resources'), for: 'App\\Filament\\Server\\Resources')
             ->discoverPages(in: app_path('Filament/Server/Pages'), for: 'App\\Filament\\Server\\Pages')
             ->discoverWidgets(in: app_path('Filament/Server/Widgets'), for: 'App\\Filament\\Server\\Widgets')
-            ->middleware([
+            ->tenantMiddleware([
                 ServerSubject::class,
             ]);
     }


### PR DESCRIPTION
Closes #1786
Supersedes #1787

[`->middleware()`](https://github.com/filamentphp/filament/blob/4.x/packages/panels/routes/web.php#L26) runs prior to [`->tenantMiddleware()`](https://github.com/filamentphp/filament/blob/4.x/packages/panels/routes/web.php#L171) so [`IdentifyTenant`](https://github.com/filamentphp/filament/blob/4.x/packages/panels/src/Http/Middleware/IdentifyTenant.php#L38) wasn't loaded and we couldn't use `Filament::getTenant()`.