### PR TITLE
Revert "Fix server owner permissions (#1703)"

### DIFF
--- a/app/Services/Servers/GetUserPermissionsService.php
+++ b/app/Services/Servers/GetUserPermissionsService.php
@@ -17,10 +17,6 @@ class GetUserPermissionsService
      */
     public function handle(Server $server, User $user): array
     {
-        if ($user->id === $server->owner_id) {
-            return ['*'];
-        }
-
         if ($user->isAdmin() && ($user->can('view', $server) || $user->can('update', $server))) {
             $permissions = $user->can('update', $server) ? ['*'] : ['websocket.connect', 'backup.read'];
 
@@ -29,6 +25,10 @@ class GetUserPermissionsService
             $permissions[] = 'admin.websocket.transfer';
 
             return $permissions;
+        }
+
+        if ($user->id === $server->owner_id) {
+            return ['*'];
         }
 
         /** @var Subuser|null $subuserPermissions */


### PR DESCRIPTION
Closes #1796 
This reverts commit df4543a079e787ebc2a04b691b3935fa1cade408.

If the admin user is the owner of the server then it won't get `'admin.websocket.errors','admin.websocket.install','admin.websocket.transfer'` so it won't be able to see install logs.