### PR TITLE
Remove `hintCopy` from EditNode autosize configuration

### DIFF
--- a/app/Filament/Admin/Resources/Nodes/Pages/EditNode.php
+++ b/app/Filament/Admin/Resources/Nodes/Pages/EditNode.php
@@ -591,7 +591,6 @@ class EditNode extends EditRecord
                                                     ->label(trans('admin/node.auto_command'))
                                                     ->readOnly()
                                                     ->autosize()
-                                                    ->hintCopy()
                                                     ->formatStateUsing(fn (NodeAutoDeployService $service, Node $node, Set $set, Get $get) => $set('generatedToken', $service->handle(request(), $node, $get('docker')))),
                                             ])
                                             ->mountUsing(function (Schema $schema) {


### PR DESCRIPTION
It has been removed since it’s not available, and unfortunately, there is no good replacement for it.

`Method 'hintCopy' not found in \Filament\Forms\Components\Textarea`

It would be possible to use the `TextInput`, but that didn’t work for me either. Therefore, I suggest removing it to avoid confusion, as it’s not needed at the moment.

Maybe a `// TODO: Add copy button` comment could be added so it can be revisited later.
