### PR TITLE
Fix 500 "No route found" when creating db host

### DIFF
--- a/app/Http/Controllers/Api/Application/DatabaseHosts/DatabaseHostController.php
+++ b/app/Http/Controllers/Api/Application/DatabaseHosts/DatabaseHostController.php
@@ -77,7 +77,7 @@ class DatabaseHostController extends ApplicationApiController
         return $this->fractal->item($databaseHost)
             ->transformWith($this->getTransformer(DatabaseHostTransformer::class))
             ->addMeta([
-                'resource' => route('api.application.databases.view', [
+                'resource' => route('api.application.databasehosts.view', [
                     'database_host' => $databaseHost->id,
                 ]),
             ])


### PR DESCRIPTION
This fixes existing issue with application api when creating Database Host.

Pelican API was throwing error 500 "No route found" (yes, 500 and no route), yet still creating DB host entry.