### PR TITLE
Fix weird postgres behavior when selecting mounts

### DIFF
--- a/app/Filament/Admin/Resources/Mounts/MountResource.php
+++ b/app/Filament/Admin/Resources/Mounts/MountResource.php
@@ -162,12 +162,8 @@ class MountResource extends Resource
                     Section::make()->schema([
                         Select::make('eggs')->multiple()
                             ->label(trans('admin/mount.eggs'))
-                            ->relationship('eggs', 'name', function (Builder $query) {
-                                // Selecting only non-json fields to prevent Postgres from choking on DISTINCT JSON columns
-                                return $query
-                                    ->select(['eggs.id', 'eggs.name'])
-                                    ->orderBy('eggs.name');
-                            })
+                            // Selecting only non-json fields to prevent Postgres from choking on DISTINCT JSON columns
+                            ->relationship('eggs', 'name', fn (Builder $query) => $query->select(['eggs.id', 'eggs.name']))
                             ->preload(),
                         Select::make('nodes')->multiple()
                             ->label(trans('admin/mount.nodes'))


### PR DESCRIPTION
Basically I use Pelican with Postgres (I know it's not recommended, but still) and on New Mount page in admin area I get following error:
```
SQLSTATE[42883]: Undefined function: 7 ERROR: could not identify an equality operator for type json 
LINE 1: select distinct "eggs".* from "eggs" left join "mountables" ... ^ 
(Connection: pgsql, SQL: select distinct "eggs".* from "eggs" left join "mountables" on "eggs"."id" = "mountables"."mountable_id" order by "eggs"."name" asc limit 50) 
(View: /var/www/html/vendor/filament/forms/resources/views/components/select.blade.php) 
(View: /var/www/html/vendor/filament/forms/resources/views/components/select.blade.php) 
(View: /var/www/html/vendor/filament/forms/resources/views/components/select.blade.php) 
(View: /var/www/html/vendor/filament/forms/resources/views/components/select.blade.php) 
(View: /var/www/html/vendor/filament/forms/resources/views/components/select.blade.php)
```

I'm not sure if this the correct solution, but I opted for selecting only distinct id and name to prevent Postgres from comparing JSON columns