### PR TITLE
Fix admin serverlist search

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/ListServers.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/ListServers.php
@@ -16,6 +16,7 @@ use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListServers extends ListRecords
 {
@@ -47,7 +48,9 @@ class ListServers extends ListRecords
                     ->searchable(),
                 TextColumn::make('name')
                     ->label(trans('admin/server.name'))
-                    ->searchable()
+                    ->searchable(query: fn (Builder $query, string $search) => $query->where(
+                        Server::query()->qualifyColumn('name'), 'like', "%{$search}%")
+                    )
                     ->sortable(),
                 TextColumn::make('node.name')
                     ->label(trans('admin/server.node'))


### PR DESCRIPTION
When searching servers in admin area a SQL error is thrown:
```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column &#039;name&#039;
in WHERE is ambiguous (Connection: mariadb, 
SQL: select count(*) as aggregate from `servers` left join `nodes` on `servers`.`node_id` = `nodes`.`id` 
where `node_id` in (1) and (
    `name` like %ddfj% 
    or exists (select * from `eggs` where `servers`.`egg_id` = `eggs`.`id` and `name` like %ddfj%) 
    or exists (select * from `users` where `servers`.`owner_id` = `users`.`id` and `username` like %ddfj%)
)) 
(View: /var/www/pelican/vendor/filament/tables/resources/views/index.blade.php) 
(View: /var/www/pelican/vendor/filament/tables/resources/views/index.blade.php)
```

This commit fixes described issue