### PR TITLE
Allow to "embed" server list

### DIFF
--- a/app/Filament/App/Resources/Servers/ServerResource.php
+++ b/app/Filament/App/Resources/Servers/ServerResource.php
@@ -33,7 +33,7 @@ class ServerResource extends Resource
         ];
     }
 
-    public static function embedServerList(bool $condition = true)
+    public static function embedServerList(bool $condition = true): void
     {
         static::$slug = $condition ? null : '/';
         static::$shouldRegisterNavigation = $condition;


### PR DESCRIPTION
Isn't really doing anything on it's own, but allows plugins to "embed" the server list as normal page when expanding the `app` panel.