### PR TITLE
Add session key to use last used node, instead of latest created node

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
@@ -116,7 +116,7 @@ class CreateServer extends CreateRecord
                                 ->prefixIcon('tabler-server-2')
                                 ->selectablePlaceholder(false)
                                 ->default(function () {
-                                    $lastUsedNode = session()->get('lastUsedNode');
+                                    $lastUsedNode = session()->get('last_utilized_node');
 
                                     if ($lastUsedNode && user()?->accessibleNodes()->where('id', $lastUsedNode)->exists()) {
                                         $this->node = Node::find($lastUsedNode);


### PR DESCRIPTION
Closes #1234 
-
User experience improvements:

* The form now attempts to pre-select the last used node by retrieving it from the session, provided the user still has access to that node. If not, it falls back to the latest accessible node.
* After a server is created, the selected node is saved to the session as `lastUsedNode`, ensuring future server creations default to the user's previous choice.