### PR TITLE
Hide new allocation action if server has 0 allocations.

### DIFF
--- a/app/Filament/Server/Resources/Allocations/AllocationResource.php
+++ b/app/Filament/Server/Resources/Allocations/AllocationResource.php
@@ -105,7 +105,7 @@ class AllocationResource extends Resource
                     ->icon(fn () => $server->allocations()->count() >= $server->allocation_limit ? 'tabler-network-off' : 'tabler-network')
                     ->authorize(fn () => user()?->can(Permission::ACTION_ALLOCATION_CREATE, $server))
                     ->tooltip(fn () => $server->allocations()->count() >= $server->allocation_limit ? trans('server/network.limit') : trans('server/network.add'))
-                    ->hidden(fn () => !config('panel.client_features.allocations.enabled'))
+                    ->hidden(fn () => !config('panel.client_features.allocations.enabled') || $server->allocation === null)
                     ->disabled(fn () => $server->allocations()->count() >= $server->allocation_limit)
                     ->color(fn () => $server->allocations()->count() >= $server->allocation_limit ? 'danger' : 'primary')
                     ->action(function (FindAssignableAllocationService $service) use ($server) {


### PR DESCRIPTION
If a server has 0 allocations, do not show the create allocation button.