### PR TITLE
Encode file contents to utf-8

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
@@ -157,7 +157,7 @@ class EditServer extends EditRecord
                                                         try {
                                                             $logs = $serverRepository->setServer($server)->getInstallLogs();
 
-                                                            return mb_convert_encoding($logs, 'UTF-8', ['UTF-8', 'ISO-8859-1', 'Windows-1252', 'ASCII']);
+                                                            return mb_convert_encoding($logs, 'UTF-8', ['UTF-8', 'UTF-16', 'ISO-8859-1', 'Windows-1252', 'ASCII']);
                                                         } catch (ConnectionException) {
                                                             Notification::make()
                                                                 ->title(trans('admin/server.notifications.error_connecting', ['node' => $server->node->name]))

--- a/app/Filament/Server/Resources/Files/Pages/EditFiles.php
+++ b/app/Filament/Server/Resources/Files/Pages/EditFiles.php
@@ -173,7 +173,7 @@ class EditFiles extends Page
                                 try {
                                     $contents = $this->getDaemonFileRepository()->getContent($this->path, config('panel.files.max_edit_size'));
 
-                                    return mb_convert_encoding($contents, 'UTF-8', ['UTF-8', 'ISO-8859-1', 'Windows-1252', 'ASCII']);
+                                    return mb_convert_encoding($contents, 'UTF-8', ['UTF-8', 'UTF-16', 'ISO-8859-1', 'Windows-1252', 'ASCII']);
                                 } catch (FileSizeTooLargeException) {
                                     AlertBanner::make('file_too_large')
                                         ->title(trans('server/file.alerts.file_too_large.title', ['name' => basename($this->path)]))


### PR DESCRIPTION
Closes #1606

ISO-8859-1 file:
<img width="349" height="259" alt="grafik" src="https://github.com/user-attachments/assets/fae055dd-e386-4ccb-bf1d-3704be250afd" />

UTF-16LE file:
<img width="1117" height="882" alt="grafik" src="https://github.com/user-attachments/assets/915d4e6b-0239-4b05-9baa-5aa8e647e00a" />