### PR TITLE
Remove 'required' rule from egg-garrys-mod.yaml

### DIFF
--- a/database/Seeders/eggs/source-engine/egg-garrys-mod.yaml
+++ b/database/Seeders/eggs/source-engine/egg-garrys-mod.yaml
@@ -153,7 +153,6 @@ variables:
     user_viewable: true
     user_editable: true
     rules:
-      - required
       - boolean
     sort: 8
   -


### PR DESCRIPTION
Removed 'required' rule from the configuration.

Fixes part of : #1829 as discussed in the Issue if a Boolean is required it expects it to have a value if the toggle is not active the value right now is empty which results in an error. 

Since this is a standard egg this was changed here but for the other eggs mentioned in the issue we need to do that in the Steamcmd-eggs repo 