### PR TITLE
Delete ssh keys shouldn't be a POST & Cleanup routes

### DIFF
--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -36,7 +36,7 @@ Route::prefix('/account')->middleware(AccountSubject::class)->group(function () 
     Route::prefix('/ssh-keys')->group(function () {
         Route::get('/', [Client\SSHKeyController::class, 'index']);
         Route::post('/', [Client\SSHKeyController::class, 'store']);
-        Route::delete('/{identifier}', [Client\SSHKeyController::class, 'delete']);
+        Route::delete('/{fingerprint}', [Client\SSHKeyController::class, 'delete']);
     });
 });
 

--- a/tests/Integration/Api/Client/SSHKeyControllerTest.php
+++ b/tests/Integration/Api/Client/SSHKeyControllerTest.php
@@ -40,20 +40,13 @@ class SSHKeyControllerTest extends ClientApiIntegrationTestCase
         $key = UserSSHKey::factory()->for($user)->create();
         $key2 = UserSSHKey::factory()->for($user2)->create();
 
-        $endpoint = '/api/client/account/ssh-keys/remove';
-
         $this->actingAs($user);
-        $this->deleteJson($endpoint)
-            ->assertUnprocessable()
-            ->assertJsonPath('errors.0.meta', ['source_field' => 'fingerprint', 'rule' => 'required']);
-
-        $this->deleteJson($endpoint, ['fingerprint' => $key->fingerprint])->assertNoContent();
+        $this->delete('/api/client/account/ssh-keys/' . $key->fingerprint)->assertNoContent();
 
         $this->assertSoftDeleted($key);
         $this->assertNotSoftDeleted($key2);
 
-        $this->deleteJson($endpoint, ['fingerprint' => $key->fingerprint])->assertNoContent();
-        $this->deleteJson($endpoint, ['fingerprint' => $key2->fingerprint])->assertNoContent();
+        $this->delete('/api/client/account/ssh-keys/' . $key2->fingerprint)->assertNotFound();
 
         $this->assertNotSoftDeleted($key2);
     }


### PR DESCRIPTION
**BREAKING API CHANGE**
POST client/account/ssh-keys/remove (fingerprint body) => DELETE client/account/ssh-keys/{fingerprint}

<img width="292" height="263" alt="image" src="https://github.com/user-attachments/assets/712a398b-348f-4c85-976e-4d35b916ea10" />
<img width="292" height="263" alt="image" src="https://github.com/user-attachments/assets/9dc7ef90-c427-41db-bcbd-226277659e0b" />
