### PR TITLE
Fix `Policies` modelname are case sensitive

### DIFF
--- a/app/Policies/ApiKeyPolicy.php
+++ b/app/Policies/ApiKeyPolicy.php
@@ -6,5 +6,5 @@ class ApiKeyPolicy
 {
     use DefaultPolicies;
 
-    protected string $modelName = 'apikey';
+    protected string $modelName = 'apiKey';
 }

--- a/app/Policies/DatabaseHostPolicy.php
+++ b/app/Policies/DatabaseHostPolicy.php
@@ -9,7 +9,7 @@ class DatabaseHostPolicy
 {
     use DefaultPolicies;
 
-    protected string $modelName = 'databasehost';
+    protected string $modelName = 'databaseHost';
 
     public function before(User $user, string $ability, string|DatabaseHost $databaseHost): ?bool
     {


### PR DESCRIPTION
They need to match RolePermissionModels since #1892
https://github.com/pelican-dev/panel/blob/d0af45a0c76c53230ee209086c31dc37765a5a8c/app/Enums/RolePermissionModels.php#L7-L16