### PR TITLE
feat: add user api management via application api

### DIFF
--- a/app/Http/Controllers/Api/Application/Users/UserApiKeyController.php
+++ b/app/Http/Controllers/Api/Application/Users/UserApiKeyController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Api\Application\Users;
+
+use App\Exceptions\DisplayException;
+use App\Facades\Activity;
+use App\Http\Controllers\Api\Application\ApplicationApiController;
+use App\Http\Requests\Api\Application\Users\ApiKeys\DeleteUserApiKeyRequest;
+use App\Http\Requests\Api\Application\Users\ApiKeys\GetUserApiKeysRequest;
+use App\Http\Requests\Api\Application\Users\ApiKeys\StoreUserApiKeyRequest;
+use App\Models\ApiKey;
+use App\Models\User;
+use App\Transformers\Api\Application\ApiKeyTransformer;
+use Illuminate\Http\JsonResponse;
+
+class UserApiKeyController extends ApplicationApiController
+{
+    /**
+     * Return all API keys associated with the given user.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function index(GetUserApiKeysRequest $request, User $user): array
+    {
+        $apiKeys = $user->apiKeys()->latest('id')->get();
+
+        return $this->fractal->collection($apiKeys)
+            ->transformWith($this->getTransformer(ApiKeyTransformer::class))
+            ->toArray();
+    }
+
+    /**
+     * Create a new API key for the given user.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function store(StoreUserApiKeyRequest $request, User $user): array
+    {
+        if ($user->apiKeys()->count() >= config('panel.api.key_limit')) {
+            throw new DisplayException('This user has reached the account limit for number of API keys.');
+        }
+
+        $token = $user->createToken(
+            $request->input('description'),
+            $request->input('allowed_ips')
+        );
+
+        Activity::event('user:api-key.create')
+            ->subject($user, $token->accessToken)
+            ->property('identifier', $token->accessToken->identifier)
+            ->log();
+
+        return $this->fractal->item($token->accessToken)
+            ->transformWith($this->getTransformer(ApiKeyTransformer::class))
+            ->addMeta(['secret_token' => $token->plainTextToken])
+            ->toArray();
+    }
+
+    /**
+     * Delete the specified API key for the given user.
+     */
+    public function delete(DeleteUserApiKeyRequest $request, User $user, string $identifier): JsonResponse
+    {
+        /** @var ApiKey $key */
+        $key = $user->apiKeys()
+            ->where('identifier', $identifier)
+            ->firstOrFail();
+
+        Activity::event('user:api-key.delete')
+            ->subject($user, $key)
+            ->property('identifier', $key->identifier)
+            ->log();
+
+        $key->delete();
+
+        return new JsonResponse([], JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Requests/Api/Application/Users/ApiKeys/DeleteUserApiKeyRequest.php
+++ b/app/Http/Requests/Api/Application/Users/ApiKeys/DeleteUserApiKeyRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Requests\Api\Application\Users\ApiKeys;
+
+use App\Http\Requests\Api\Application\ApplicationApiRequest;
+use App\Models\User;
+use App\Services\Acl\Api\AdminAcl as Acl;
+
+class DeleteUserApiKeyRequest extends ApplicationApiRequest
+{
+    protected ?string $resource = User::RESOURCE_NAME;
+
+    protected int $permission = Acl::WRITE;
+}

--- a/app/Http/Requests/Api/Application/Users/ApiKeys/GetUserApiKeysRequest.php
+++ b/app/Http/Requests/Api/Application/Users/ApiKeys/GetUserApiKeysRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Requests\Api\Application\Users\ApiKeys;
+
+use App\Http\Requests\Api\Application\ApplicationApiRequest;
+use App\Models\User;
+use App\Services\Acl\Api\AdminAcl as Acl;
+
+class GetUserApiKeysRequest extends ApplicationApiRequest
+{
+    protected ?string $resource = User::RESOURCE_NAME;
+
+    protected int $permission = Acl::READ;
+}

--- a/app/Http/Requests/Api/Application/Users/ApiKeys/StoreUserApiKeyRequest.php
+++ b/app/Http/Requests/Api/Application/Users/ApiKeys/StoreUserApiKeyRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Api\Application\Users\ApiKeys;
+
+use App\Http\Requests\Api\Application\ApplicationApiRequest;
+use App\Models\ApiKey;
+use App\Models\User;
+use App\Services\Acl\Api\AdminAcl as Acl;
+use Exception;
+use Illuminate\Validation\Validator;
+use IPTools\Range;
+
+class StoreUserApiKeyRequest extends ApplicationApiRequest
+{
+    protected ?string $resource = User::RESOURCE_NAME;
+
+    protected int $permission = Acl::WRITE;
+
+    /** @return array<array-key, string|string[]> */
+    public function rules(): array
+    {
+        $rules = ApiKey::getRules();
+
+        return [
+            'description' => $rules['memo'],
+            'allowed_ips' => [...$rules['allowed_ips'], 'max:50'],
+            'allowed_ips.*' => 'string',
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            if (!is_array($ips = $this->input('allowed_ips'))) {
+                return;
+            }
+
+            foreach ($ips as $index => $ip) {
+                $valid = false;
+
+                try {
+                    $valid = Range::parse($ip)->valid();
+                } catch (Exception $exception) {
+                    if ($exception->getMessage() !== 'Invalid IP address format') {
+                        throw $exception;
+                    }
+                } finally {
+                    $validator->errors()->addIf(!$valid, "allowed_ips.{$index}", '"' . $ip . '" is not a valid IP address or CIDR range.');
+                }
+            }
+        });
+    }
+}

--- a/app/Transformers/Api/Application/ApiKeyTransformer.php
+++ b/app/Transformers/Api/Application/ApiKeyTransformer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Transformers\Api\Application;
+
+use App\Models\ApiKey;
+
+class ApiKeyTransformer extends BaseTransformer
+{
+    public function getResourceName(): string
+    {
+        return ApiKey::RESOURCE_NAME;
+    }
+
+    /**
+     * @param  ApiKey  $apiKey
+     * @return array<string, mixed>
+     */
+    public function transform($apiKey): array
+    {
+        return [
+            'id' => $apiKey->id,
+            'user_id' => $apiKey->user_id,
+            'key_type' => $apiKey->key_type,
+            'identifier' => $apiKey->identifier,
+            'memo' => $apiKey->memo,
+            'allowed_ips' => $apiKey->allowed_ips,
+            'permissions' => $apiKey->permissions,
+            'last_used_at' => $apiKey->last_used_at?->toAtomString(),
+            'expires_at' => $apiKey->expires_at?->toAtomString(),
+            'created_at' => $apiKey->created_at->toAtomString(),
+            'updated_at' => $apiKey->updated_at->toAtomString(),
+        ];
+    }
+}

--- a/routes/api-application.php
+++ b/routes/api-application.php
@@ -23,6 +23,12 @@ Route::prefix('/users')->group(function () {
     Route::patch('/{user:id}/roles/remove', [Application\Users\UserController::class, 'removeRoles']);
 
     Route::delete('/{user:id}', [Application\Users\UserController::class, 'delete']);
+
+    Route::prefix('/{user:id}/api-keys')->group(function () {
+        Route::get('/', [Application\Users\UserApiKeyController::class, 'index'])->name('api.application.users.api-keys');
+        Route::post('/', [Application\Users\UserApiKeyController::class, 'store']);
+        Route::delete('/{identifier}', [Application\Users\UserApiKeyController::class, 'delete'])->name('api.application.users.api-keys.delete');
+    });
 });
 
 /*

--- a/tests/Integration/Api/Application/Users/UserApiKeyControllerTest.php
+++ b/tests/Integration/Api/Application/Users/UserApiKeyControllerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Integration\Api\Application\Users;
+
+use App\Models\ApiKey;
+use App\Models\User;
+use App\Services\Acl\Api\AdminAcl;
+use App\Tests\Integration\Api\Application\ApplicationApiIntegrationTestCase;
+use App\Transformers\Api\Application\ApiKeyTransformer;
+use Illuminate\Http\Response;
+
+class UserApiKeyControllerTest extends ApplicationApiIntegrationTestCase
+{
+    public function test_user_api_keys_are_listed(): void
+    {
+        $user = User::factory()->create();
+        $firstKey = ApiKey::factory()->for($user)->create([
+            'key_type' => ApiKey::TYPE_ACCOUNT,
+            'memo' => 'first key',
+        ]);
+        $secondKey = ApiKey::factory()->for($user)->create([
+            'key_type' => ApiKey::TYPE_ACCOUNT,
+            'memo' => 'second key',
+        ]);
+
+        $firstKey->refresh();
+        $secondKey->refresh();
+
+        $response = $this->getJson('/api/application/users/' . $user->id . '/api-keys')
+            ->assertOk()
+            ->assertJsonPath('object', 'list')
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.object', ApiKey::RESOURCE_NAME);
+
+        $transformer = $this->getTransformer(ApiKeyTransformer::class);
+
+        $this->assertSame($transformer->transform($secondKey), $response->json('data.0.attributes'));
+        $this->assertSame($transformer->transform($firstKey), $response->json('data.1.attributes'));
+    }
+
+    public function test_user_api_key_can_be_created(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/application/users/' . $user->id . '/api-keys', [
+            'description' => 'Test description',
+            'allowed_ips' => ['127.0.0.1'],
+        ])
+            ->assertOk()
+            ->assertJsonPath('object', ApiKey::RESOURCE_NAME);
+
+        /** @var ApiKey $key */
+        $key = ApiKey::query()->where('identifier', $response->json('attributes.identifier'))->firstOrFail();
+
+        $transformer = $this->getTransformer(ApiKeyTransformer::class);
+
+        $this->assertSame($transformer->transform($key), $response->json('attributes'));
+        $this->assertSame($key->token, $response->json('meta.secret_token'));
+
+        $this->assertActivityFor('user:api-key.create', $this->getApiUser(), [$key, $user]);
+    }
+
+    public function test_api_key_limit_is_enforced(): void
+    {
+        $user = User::factory()->create();
+        ApiKey::factory()->times(config('panel.api.key_limit', 25))->for($user)->create([
+            'key_type' => ApiKey::TYPE_ACCOUNT,
+        ]);
+
+        $this->postJson('/api/application/users/' . $user->id . '/api-keys', [
+            'description' => 'Test description',
+            'allowed_ips' => ['127.0.0.1'],
+        ])
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath('errors.0.code', 'DisplayException')
+            ->assertJsonPath('errors.0.detail', 'This user has reached the account limit for number of API keys.');
+    }
+
+    public function test_user_api_key_can_be_deleted(): void
+    {
+        $user = User::factory()->create();
+        $key = ApiKey::factory()->for($user)->create([
+            'key_type' => ApiKey::TYPE_ACCOUNT,
+        ]);
+
+        $this->deleteJson('/api/application/users/' . $user->id . '/api-keys/' . $key->identifier)
+            ->assertStatus(Response::HTTP_NO_CONTENT);
+
+        $this->assertDatabaseMissing('api_keys', ['id' => $key->id]);
+
+        $this->assertActivityFor('user:api-key.delete', $this->getApiUser(), [$user, $key]);
+    }
+
+    public function test_request_without_permission_is_denied(): void
+    {
+        $this->createNewDefaultApiKey($this->getApiUser(), [User::RESOURCE_NAME => AdminAcl::NONE]);
+
+        $user = User::factory()->create();
+
+        $response = $this->getJson('/api/application/users/' . $user->id . '/api-keys');
+        $this->assertAccessDeniedJson($response);
+    }
+}


### PR DESCRIPTION
This PR adds API functionality to manage user API keys via application API.

**Caveats:**
- this feature has partial functional implementation for livewire (ability to view and delete user api keys from admin panel, but not create them

**Motivation:** idk, this allows to use pelican headless. Also someone on Discord wanted to use pelican for hosting but not giving users full panel access: [Link to Message](https://discord.com/channels/1218730176297439332/1218733575151816774/1442441047677337622)