### PR TITLE
Add custom render hooks to our footer

### DIFF
--- a/app/Enums/CustomRenderHooks.php
+++ b/app/Enums/CustomRenderHooks.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum CustomRenderHooks: string
+{
+    case FooterStart = 'pelican::footer.start';
+    case FooterEnd = 'pelican::footer.end';
+}

--- a/resources/views/filament/layouts/footer.blade.php
+++ b/resources/views/filament/layouts/footer.blade.php
@@ -1,5 +1,5 @@
 <footer class="flex flex-col items-center justify-center text-center space-y-2 p-4 text-gray-600 dark:text-gray-400">
-    {{ \Filament\Support\Facades\FilamentView::renderHook('pelican::footer-start') }}
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\App\Enums\CustomRenderHooks::FooterStart->value) }}
 
     <a class="font-semibold" href="https://pelican.dev/docs/#core-team" target="_blank">
         &copy; {{ date('Y') }} Pelican
@@ -15,5 +15,5 @@
         </div>
     @endif
 
-    {{ \Filament\Support\Facades\FilamentView::renderHook('pelican::footer-end') }}
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\App\Enums\CustomRenderHooks::FooterEnd->value) }}
 </footer>


### PR DESCRIPTION
Allows plugins to add to our footer, e.g. additional links or info texts.