### PR TITLE
fix: child folder detection in ZIP for plugin extraction

### DIFF
--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -338,7 +338,7 @@ class PluginService
             File::deleteDirectory(plugin_path($pluginName));
         }
 
-        $extractPath = $zip->locateName($pluginName . '/') !== false ? base_path('plugins') : plugin_path($pluginName);
+        $extractPath = $zip->locateName($pluginName . '/plugin.json') !== false ? base_path('plugins') : plugin_path($pluginName);
 
         if (!$zip->extractTo($extractPath)) {
             $zip->close();


### PR DESCRIPTION
`locateName` does not support directory detection, fixed with new changes

Plugins can now correctly be uploaded as 1 zipped directory.