### PR TITLE
Fix typo in suspend method documentation

### DIFF
--- a/app/Http/Controllers/Api/Application/Servers/ServerManagementController.php
+++ b/app/Http/Controllers/Api/Application/Servers/ServerManagementController.php
@@ -34,7 +34,7 @@ class ServerManagementController extends ApplicationApiController
     }
 
     /**
-     * Suspsend
+     * Suspend
      *
      * Suspend a server on the Panel.
      *


### PR DESCRIPTION
# Changes 
This pull request includes a small change to fix a typo in the documentation comment of the `ServerManagementController` class. The word "Suspsend" was corrected to "Suspend".