### PR TITLE
Disable Captcha & Oauth Settings actions when read only

### DIFF
--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -297,11 +297,13 @@ class Settings extends Page implements HasSchemas
                     Actions::make([
                         Action::make("disable_captcha_$id")
                             ->visible(fn (Get $get) => $get("CAPTCHA_{$id}_ENABLED"))
+                            ->disabled(fn () => !user()?->can('update settings'))
                             ->label(trans('admin/setting.captcha.disable'))
                             ->color('danger')
                             ->action(fn (Set $set) => $set("CAPTCHA_{$id}_ENABLED", false)),
                         Action::make("enable_captcha_$id")
                             ->visible(fn (Get $get) => !$get("CAPTCHA_{$id}_ENABLED"))
+                            ->disabled(fn () => !user()?->can('update settings'))
                             ->label(trans('admin/setting.captcha.enable'))
                             ->color('success')
                             ->action(fn (Set $set) => $set("CAPTCHA_{$id}_ENABLED", true)),
@@ -568,11 +570,13 @@ class Settings extends Page implements HasSchemas
                     Actions::make([
                         Action::make("disable_oauth_$id")
                             ->visible(fn (Get $get) => $get($key))
+                            ->disabled(fn () => !user()?->can('update settings'))
                             ->label(trans('admin/setting.oauth.disable'))
                             ->color('danger')
                             ->action(fn (Set $set) => $set($key, false)),
                         Action::make("enable_oauth_$id")
                             ->visible(fn (Get $get) => !$get($key))
+                            ->disabled(fn () => !user()?->can('update settings'))
                             ->label(trans('admin/setting.oauth.enable'))
                             ->color('success')
                             ->steps($schema->getSetupSteps())


### PR DESCRIPTION
Closes #1967

I used `disabled()` instead of `authorize()` cause i thought the section would look weird if it was completely empty.