### PR TITLE
Fixed tiny typo

### DIFF
--- a/lang/en/admin/setting.php
+++ b/lang/en/admin/setting.php
@@ -109,7 +109,7 @@ return [
             'helper' => 'Toggle if Users can create allocations via the client area.',
             'question' => 'Allow Users to create Allocations?',
             'create_new' => 'Create new allocations if none available?',
-            'create_new_help' => 'When enabled, creates new allocations. When disabled, only assigns from existing unassigned allocations. Both options faktor the port range below into account.',
+            'create_new_help' => 'When enabled, creates new allocations. When disabled, only assigns from existing unassigned allocations. Both options factor the port range below into account.',
             'start' => 'Start Port',
             'end' => 'End Port',
         ],


### PR DESCRIPTION
On setting, new allocation has a tiny typo.
Changes:
faktor -> factor