### PR TITLE
Update paper egg to use their new domain

### DIFF
--- a/database/Seeders/eggs/minecraft/egg-paper.yaml
+++ b/database/Seeders/eggs/minecraft/egg-paper.yaml
@@ -37,7 +37,7 @@ config:
   stop: stop
 scripts:
   installation:
-    script: |+
+    script: |-
       #!/bin/ash
       # Paper Installation Script
       #
@@ -89,7 +89,6 @@ scripts:
           echo -e "Downloading MC server.properties"
           curl -o server.properties https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/server.properties
       fi
-
     container: 'ghcr.io/pelican-eggs/installers:alpine'
     entrypoint: ash
 variables:


### PR DESCRIPTION
Change from api.papermc.io/v2 to fill.papermc.io/v3