### PR TITLE
changed docker panel restart to unless-stopped

### DIFF
--- a/compose-full-stack.yml
+++ b/compose-full-stack.yml
@@ -53,7 +53,7 @@ services:
   panel:
     image: ghcr.io/pelican-dev/panel:latest
     build: .
-    restart: always
+    restart: unless-stopped
     networks:
       - default
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -31,7 +31,7 @@ services:
   panel:
     image: ghcr.io/pelican-dev/panel:latest
     build: .
-    restart: always
+    restart: unless-stopped
     networks:
       - default
     ports:


### PR DESCRIPTION
`restart: unless-stopped` is the way to go for the Pelican Docker container. It’ll restart if it crashes or the server reboots, but it won’t bug you if you manually stopped it. Makes updates and maintenance way easier. 
`restart: always` can be risky because the container will keep restarting even if it keeps crashing. This can create a loop and use up resources unnecessarily, especially during updates or if something goes wrong.