### PR TITLE
Fix Docker build command in comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Pelican Production Dockerfile
 
 ##
-#  If you want to build this locally you want to run `docker build -f Dockerfile.dev`
+#  If you want to build this locally you want to run `docker build -f Dockerfile.dev .`
 ##
 
 # ================================


### PR DESCRIPTION
Add "." as buildx requires the current working directory (the panel root dir) as an argument.