### PR TITLE
fix: Remove plugins directory before linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ RUN chown root:www-data ./ \
     && ln -sf /var/www/html/storage/app/public /var/www/html/public/storage \
     && ln -s  /pelican-data/storage/avatars /var/www/html/storage/app/public/avatars \
     && ln -s  /pelican-data/storage/fonts /var/www/html/storage/app/public/fonts \
+    && rm -r  /var/www/html/plugins \
     && ln -s  /pelican-data/plugins /var/www/html/plugins \
     # Allow www-data write permissions where necessary
     && chown -R www-data:www-data /pelican-data ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \


### PR DESCRIPTION
The `plugins` directory already exists during when creating the Symlinks. This causes the `ln` command to create a symlink inside the directory instead of replacing it.

This currently causes issues in dockerized installs, throwing errors like `ZipArchive::extractTo(): Permission denied` when attempting to install any plugin through the web panel.

Current incorrect structure:
```
/var/www/html
- plugins
  - plugins -> /pelican-data/plugins (Symlink)
```

Removing the existing plugins directory before creating the symlink. Gives us the correct structure:
```
/var/www/html
- plugins -> /pelican-data/plugins (Symlink)
```