### PR TITLE
Don't log yarn exceptions as error but warning

### DIFF
--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -265,7 +265,7 @@ class PluginService
                 throw ($exception);
             }
 
-            Log::warning($exception->getMessage());
+            Log::warning($exception->getMessage(), ['exception' => $exception]);
         }
 
         return false;


### PR DESCRIPTION
Those are "soft" errors and can be ignored most of the time.