### PR TITLE
Fix plugin settings not showing on non-admin plugins

### DIFF
--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -306,11 +306,10 @@ class Plugin extends Model implements HasPluginSettings
     public function hasSettings(): bool
     {
         try {
-            $pluginObject = filament($this->id);
+            $pluginObject = new ($this->fullClass());
 
             return $pluginObject instanceof HasPluginSettings;
         } catch (Exception) {
-            // Plugin is not loaded on the current panel, so no settings
         }
 
         return false;
@@ -320,13 +319,12 @@ class Plugin extends Model implements HasPluginSettings
     public function getSettingsForm(): array
     {
         try {
-            $pluginObject = filament($this->id);
+            $pluginObject = new ($this->fullClass());
 
             if ($pluginObject instanceof HasPluginSettings) {
                 return $pluginObject->getSettingsForm();
             }
         } catch (Exception) {
-            // Plugin is not loaded on the current panel, so no settings
         }
 
         return [];
@@ -336,13 +334,12 @@ class Plugin extends Model implements HasPluginSettings
     public function saveSettings(array $data): void
     {
         try {
-            $pluginObject = filament($this->id);
+            $pluginObject = new ($this->fullClass());
 
             if ($pluginObject instanceof HasPluginSettings) {
                 $pluginObject->saveSettings($data);
             }
         } catch (Exception) {
-            // Plugin is not loaded on the current panel, so no settings
         }
     }
 


### PR DESCRIPTION
Currently a plugin needs to be loaded on the `admin` in order for the plugin settings to show. This fixes that by using a temp dummy object instead of getting the plugin from filament.