### PR TITLE
Fix actions when plugin is "errored"

### DIFF
--- a/app/Filament/Admin/Resources/Plugins/PluginResource.php
+++ b/app/Filament/Admin/Resources/Plugins/PluginResource.php
@@ -202,7 +202,7 @@ class PluginResource extends Resource
                         ->icon('tabler-terminal')
                         ->color('danger')
                         ->requiresConfirmation()
-                        ->hidden(fn (Plugin $plugin) => $plugin->status === PluginStatus::NotInstalled)
+                        ->hidden(fn (Plugin $plugin) => $plugin->status === PluginStatus::NotInstalled || $plugin->status === PluginStatus::Errored)
                         ->action(function (Plugin $plugin, $livewire, PluginService $pluginService) {
                             $pluginService->uninstallPlugin($plugin);
 

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -205,7 +205,7 @@ class Plugin extends Model implements HasPluginSettings
 
     public function canDisable(): bool
     {
-        return $this->status !== PluginStatus::Disabled && $this->status !== PluginStatus::NotInstalled && $this->isCompatible();
+        return $this->status === PluginStatus::Enabled || $this->status === PluginStatus::Incompatible;
     }
 
     public function isCompatible(): bool


### PR DESCRIPTION
Do not show "disable" and "uninstall" when a plugin has errored.