### PR TITLE
add id to plugin list

### DIFF
--- a/app/Console/Commands/Plugin/ListPluginsCommand.php
+++ b/app/Console/Commands/Plugin/ListPluginsCommand.php
@@ -21,7 +21,7 @@ class ListPluginsCommand extends Command
             return;
         }
 
-        $this->table(['id', 'Name', 'Author', 'Status', 'Version', 'Panels', 'Category'], $plugins->toArray());
+        $this->table(['ID', 'Name', 'Author', 'Status', 'Version', 'Panels', 'Category'], $plugins->toArray());
 
         $this->output->newLine();
     }


### PR DESCRIPTION
Adds id to plugin list, so if you need to use cli to interact with plugins, you can see the id, instead of guessing if its my-awesome-plugin or myawesomeplugin or some other random string... 