### PR TITLE
chore: Prevent users from caching Config

### DIFF
--- a/app/Console/Commands/Overrides/ConfigCacheCommand.php
+++ b/app/Console/Commands/Overrides/ConfigCacheCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console\Commands\Overrides;
+
+use Illuminate\Foundation\Console\ConfigCacheCommand as BaseConfigCacheCommand;
+
+class ConfigCacheCommand extends BaseConfigCacheCommand
+{
+    /**
+     * Prevent config from being cached
+     */
+    public function handle()
+    {
+        $this->components->warn('Configuration caching has been disabled.');
+
+        $this->line('  Reason: This application uses dynamic plugins. Caching config');
+        $this->line('  prevents /plugins/config/*.php files from being loaded correctly.');
+    }
+}

--- a/app/Console/Commands/Overrides/OptimizeCommand.php
+++ b/app/Console/Commands/Overrides/OptimizeCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Console\Commands\Overrides;
+
+use Illuminate\Foundation\Console\OptimizeCommand as BaseOptimizeCommand;
+
+class OptimizeCommand extends BaseOptimizeCommand
+{
+    /**
+     * Prevent config from being cached
+     *
+     * @return array<string, string>
+     */
+    protected function getOptimizeTasks()
+    {
+        return array_except(parent::getOptimizeTasks(), 'config');
+    }
+}

--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -823,7 +823,6 @@ class Settings extends Page implements HasSchemas
 
             $this->writeToEnvironment($data);
 
-            Artisan::call('config:clear');
             Artisan::call('queue:restart');
 
             $this->redirect($this->getUrl());

--- a/app/Livewire/Installer/PanelInstaller.php
+++ b/app/Livewire/Installer/PanelInstaller.php
@@ -165,8 +165,6 @@ class PanelInstaller extends SimplePage implements HasForms
 
             throw new Halt(trans('installer.exceptions.write_env'));
         }
-
-        Artisan::call('config:clear');
     }
 
     public function runMigrations(): void

--- a/app/Traits/EnvironmentWriterTrait.php
+++ b/app/Traits/EnvironmentWriterTrait.php
@@ -3,6 +3,7 @@
 namespace App\Traits;
 
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\Artisan;
 use RuntimeException;
 
 trait EnvironmentWriterTrait
@@ -17,5 +18,6 @@ trait EnvironmentWriterTrait
     public function writeToEnvironment(array $values = []): void
     {
         Env::writeVariables($values, base_path('.env'), true);
+        Artisan::call('config:clear');
     }
 }


### PR DESCRIPTION
Closes #2018 
When config is cached every plugin config is null cause they use `env()`, I couldn't find anyway to circumvent this so i skipped config caching entirely.