### PR TITLE
Fix relation managers for admin server resource

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
@@ -3,8 +3,6 @@
 namespace App\Filament\Admin\Resources\Servers\Pages;
 
 use App\Enums\SuspendAction;
-use App\Filament\Admin\Resources\Servers\RelationManagers\AllocationsRelationManager;
-use App\Filament\Admin\Resources\Servers\RelationManagers\DatabasesRelationManager;
 use App\Filament\Admin\Resources\Servers\ServerResource;
 use App\Filament\Components\Actions\DeleteServerIcon;
 use App\Filament\Components\Actions\PreviewStartupAction;
@@ -1196,13 +1194,5 @@ class EditServer extends EditRecord
         };
 
         Storage::disk('public')->put(Server::ICON_STORAGE_PATH . "/$server->uuid.$normalizedExtension", $data);
-    }
-
-    public function getRelationManagers(): array
-    {
-        return [
-            AllocationsRelationManager::class,
-            DatabasesRelationManager::class,
-        ];
     }
 }

--- a/app/Filament/Admin/Resources/Servers/ServerResource.php
+++ b/app/Filament/Admin/Resources/Servers/ServerResource.php
@@ -7,6 +7,7 @@ use App\Filament\Admin\Resources\Servers\Pages\CreateServer;
 use App\Filament\Admin\Resources\Servers\Pages\EditServer;
 use App\Filament\Admin\Resources\Servers\Pages\ListServers;
 use App\Filament\Admin\Resources\Servers\RelationManagers\AllocationsRelationManager;
+use App\Filament\Admin\Resources\Servers\RelationManagers\DatabasesRelationManager;
 use App\Models\Mount;
 use App\Models\Server;
 use App\Traits\Filament\CanCustomizePages;
@@ -86,6 +87,7 @@ class ServerResource extends Resource
     {
         return [
             AllocationsRelationManager::class,
+            DatabasesRelationManager::class,
         ];
     }
 


### PR DESCRIPTION
Overriding `getRelationManagers` in `EditServer` made it impossible to register custom relation managers via `ServerResource::registerCustomRelations(...)`.