### PR TITLE
Fix Plugins Symlink in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN chown root:www-data ./ \
     && ln -sf /var/www/html/storage/app/public /var/www/html/public/storage \
     && ln -s  /pelican-data/storage/avatars /var/www/html/storage/app/public/avatars \
     && ln -s  /pelican-data/storage/fonts /var/www/html/storage/app/public/fonts \
-    && ln -s  /pelican-data/plugins /var/www/html/plugins \
+    && ln -sT  /pelican-data/plugins /var/www/html/plugins \
     # Allow www-data write permissions where necessary
     && chown -R www-data:www-data /pelican-data ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R u+rwX,g+rwX,o-rwx /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -87,7 +87,7 @@ RUN chown root:www-data ./ \
     && ln -sf /var/www/html/storage/app/public /var/www/html/public/storage \
     && ln -s  /pelican-data/storage/avatars /var/www/html/storage/app/public/avatars \
     && ln -s  /pelican-data/storage/fonts /var/www/html/storage/app/public/fonts \
-    && ln -s  /pelican-data/plugins /var/www/html/plugins \
+    && ln -sT  /pelican-data/plugins /var/www/html/plugins \
     # Allow www-data write permissions where necessary
     && chown -R www-data:www-data /pelican-data ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R u+rwX,g+rwX,o-rwx /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \


### PR DESCRIPTION
Currently, when you look into the docker image provided upstream, it creates `/var/www/html/plugins/plugins` instead of the correct `/var/www/html/plugins` folder symlinked to `/pelican-data/plugins`.

```bash
/var/www/html $ ls -alh /var/www/html/plugins/
total 12K    
drwxr-x---    1 root     www-data    4.0K Dec 19 23:44 .
drwxr-x---    1 root     www-data    4.0K Dec 19 23:44 ..
lrwxrwxrwx    1 root     root          21 Dec 19 23:44 plugins -> /pelican-data/plugins
```