### PR TITLE
Fix typo in method name

### DIFF
--- a/app/Filament/Server/Pages/ServerFormPage.php
+++ b/app/Filament/Server/Pages/ServerFormPage.php
@@ -44,7 +44,7 @@ abstract class ServerFormPage extends Page
 
     protected function authorizeAccess(): void {}
 
-    protected function fillform(): void
+    protected function fillForm(): void
     {
         $data = $this->getRecord()->attributesToArray();
 


### PR DESCRIPTION
Don't know if that typo actually broke anything but phpstorm complained anyways. :D