### PR TITLE
Fix broken download redirect

### DIFF
--- a/app/Filament/Server/Resources/Files/Pages/DownloadFiles.php
+++ b/app/Filament/Server/Resources/Files/Pages/DownloadFiles.php
@@ -50,7 +50,9 @@ class DownloadFiles extends Page
             ->property('file', $path)
             ->log();
 
-        redirect()->away($server->node->getConnectionAddress() . '/download/file?token=' . $token->toString());
+        $url = $server->node->getConnectionAddress() . '/download/file?token=' . $token->toString();
+
+        $this->redirect($url);
     }
 
     protected function authorizeAccess(): void


### PR DESCRIPTION
The file download procedure do a single redirect to the download endpoint on wings. However, if redirect respond contains a body, it will not download for some reason.

HTTP Request when actual content is sent but not trigger browser download:

```
GET https://example.com/server/________/files/download/defaultconfigs/woodenbucket-server.toml HTTP/2.0
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36
accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
accept-encoding: gzip, deflate, br
accept-language: en-US,en;q=0.9

HTTP/2.0 302
date: Sun, 04 Jan 2026 09:09:31 GMT
content-type: text/html; charset=utf-8
location: https://example.com/download/file?token=________
cache-control: no-store
expires: Fri, 01 Jan 1990 00:00:00 GMT
pragma: no-cache
status: 302 Found

<!DOCTYPE html>
<html>
  <head>
    <meta charset="UTF-8" />
    <meta http-equiv="refresh" content="0;url='https://example.com/download/file?token=________'" />
    <title>Redirecting</title>
  </head>
  <body>
    Redirecting to <a href="https://example.com/download/file?token=________">download</a>.
  </body>
</html>

GET https://example.com/download/file?token=________ HTTP/2.0
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36
accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
accept-encoding: gzip, deflate, br
accept-language: en-US,en;q=0.9

HTTP/2.0 200
content-disposition: attachment; filename="woodenbucket-server.toml"
content-type: application/octet-stream
date: Sun, 04 Jan 2026 09:09:31 GMT
content-length: 770

["Balance Options"]
    crackingTemperature = 1000
```