### PR TITLE
Improve file browser UI

### DIFF
--- a/resources/views/filament/server/pages/list-files.blade.php
+++ b/resources/views/filament/server/pages/list-files.blade.php
@@ -1,4 +1,16 @@
 <x-filament-panels::page>
+    @once
+        <style>
+            .files-selection-merged .fi-ta-header-ctn {
+                position: sticky;
+                top: 0;
+                z-index: 1;
+                -webkit-backdrop-filter: blur(8px);
+                backdrop-filter: blur(8px);
+            }
+        </style>
+    @endonce
+
     <div
         x-data="
         {


### PR DESCRIPTION
Minor changes to address some UX issue:

- Refresh: When delete or rename, no longer do a full refresh that jump the viewport around
- Show all files: To show all files beyond the limit
- Sticky header: Allows friendly interaction on mobile or when long list wanted for bulk-actions