### PR TITLE
Update database config to remove deprecation warning on php 8.5

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Str;
 
 $database = env('DB_DATABASE', 'database.sqlite');
-$datapasePath = database_path($database);
+$databasePath = database_path($database);
 
 if (str_starts_with($database, '/') || $database === ':memory:') {
     $databasePath = $database;
@@ -41,7 +41,7 @@ return [
         'sqlite' => [
             'driver' => 'sqlite',
             'url' => env('DB_URL'),
-            'database' => $datapasePath,
+            'database' => $databasePath,
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
             'busy_timeout' => null,


### PR DESCRIPTION
Small followup for #2079 to remove some annoying deprecation warnings.

https://github.com/laravel/framework/blob/adb4eb81b62694c77d3ddba4506f4b475da43fbb/config/database.php#L64