### PR TITLE
Make sure custom pages/relations don't override default pages/relations

### DIFF
--- a/app/Traits/Filament/CanCustomizePages.php
+++ b/app/Traits/Filament/CanCustomizePages.php
@@ -24,6 +24,6 @@ trait CanCustomizePages
     /** @return array<string, PageRegistration> */
     public static function getPages(): array
     {
-        return array_unique(array_merge(static::getDefaultPages(), static::$customPages), SORT_REGULAR);
+        return array_unique(array_merge(static::$customPages, static::getDefaultPages()), SORT_REGULAR);
     }
 }

--- a/app/Traits/Filament/CanCustomizeRelations.php
+++ b/app/Traits/Filament/CanCustomizeRelations.php
@@ -23,6 +23,6 @@ trait CanCustomizeRelations
     /** @return class-string<RelationManager>[] */
     public static function getRelations(): array
     {
-        return array_unique(array_merge(static::getDefaultRelations(), static::$customRelations));
+        return array_unique(array_merge(static::$customRelations, static::getDefaultRelations()));
     }
 }


### PR DESCRIPTION
Protect against plugins overriding default pages/relations.