### PR TITLE
fix webhook for Server/Installed

### DIFF
--- a/app/Jobs/ProcessWebhook.php
+++ b/app/Jobs/ProcessWebhook.php
@@ -40,9 +40,18 @@ class ProcessWebhook implements ShouldQueue
             $data = reset($data);
         }
 
+        if (is_object($data)) {
+            $data = get_object_vars($data);
+        }
+
         if (is_string($data)) {
             $data = Arr::wrap(json_decode($data, true) ?? []);
         }
+
+        if (!is_array($data)) {
+            $data = [];
+        }
+
         $data['event'] = $this->webhookConfiguration->transformClassName($this->eventName);
 
         if ($this->webhookConfiguration->type === WebhookType::Discord) {


### PR DESCRIPTION
Currently, Pelican is throwing 
```
Cannot use object of type App\Events\Server\Installed as array {"exception":"[object] (Error(code: 0): Cannot use object of type App\\Events\\Server\\Installed as array at                         
  /var/www/pelican/app/Jobs/ProcessWebhook.php:40)
```
 
for Server\Installed wbehooks.