### PR TITLE
feat: make timezone configurable via APP_TIMEZONE env var

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -8,7 +8,7 @@ return [
 
     'version' => 'canary',
 
-    'timezone' => 'UTC',
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
 
     'installed' => env('APP_INSTALLED', true),
 


### PR DESCRIPTION
## Summary

Allow users to configure the application timezone via the `APP_TIMEZONE` environment variable, defaulting to `UTC` for backwards compatibility.

## Problem

Currently the timezone is hardcoded to `UTC` in `config/app.php`:
```php
'timezone' => 'UTC',
```

This makes it impossible to configure the application timezone via environment variables, which is the standard configuration method for containerized deployments.

## Solution

Change to read from environment variable with fallback:
```php
'timezone' => env('APP_TIMEZONE', 'UTC'),
```

## Use Case

Containerized deployments (Docker, Kubernetes) where configuration is managed via environment variables rather than editing files. Users can now set `APP_TIMEZONE=America/New_York` (or any valid timezone) in their container configuration.

## Testing

- Verified the change is backwards compatible (defaults to UTC)
- Standard Laravel configuration pattern used by other settings in the same file