### PR TITLE
fix(webhooks): handle event objects and add response tracking

### DIFF
--- a/app/Jobs/ProcessWebhook.php
+++ b/app/Jobs/ProcessWebhook.php
@@ -19,6 +19,10 @@ class ProcessWebhook implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
+     * Create a new job instance.
+     *
+     * @param  WebhookConfiguration  $webhookConfiguration
+     * @param  string  $eventName
      * @param  array<mixed>  $data
      */
     public function __construct(
@@ -27,6 +31,11 @@ class ProcessWebhook implements ShouldQueue
         private array $data
     ) {}
 
+    /**
+     * Process and send the webhook, capturing HTTP response details.
+     * 
+     * @return void
+     */
     public function handle(): void
     {
         $data = $this->data[0] ?? [];

--- a/app/Models/Webhook.php
+++ b/app/Models/Webhook.php
@@ -33,6 +33,11 @@ class Webhook extends Model
         ];
     }
 
+    /**
+     * Get the prunable model query.
+     *
+     * @return Builder
+     */
     public function prunable(): Builder
     {
         return static::where('created_at', '<=', Carbon::now()->subDays(config('panel.webhook.prune_days')));

--- a/database/migrations/2026_01_17_225059_add_response_fields_to_webhooks_table.php
+++ b/database/migrations/2026_01_17_225059_add_response_fields_to_webhooks_table.php
@@ -6,6 +6,13 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * Adds response tracking columns to the webhooks table to capture HTTP response metadata.
+     *
+     * @return void
+     */
     public function up(): void
     {
         Schema::table('webhooks', function (Blueprint $table) {
@@ -15,6 +22,13 @@ return new class extends Migration
         });
     }
 
+    /**
+     * Reverse the migrations.
+     *
+     * Removes the response tracking columns from the webhooks table.
+     *
+     * @return void
+     */
     public function down(): void
     {
         Schema::table('webhooks', function (Blueprint $table) {


### PR DESCRIPTION
What didn't work:
Webhooks weren't working and failed with no error messages.

What I did:
- Convert event objects to arrays before further processing
- Save the HTTP response code and error message to database
- Added 3 database columns to collect this info

Result:
Webhooks should work fine now with accurate error messages for debugging.