### PR TITLE
Set failed plugin installs to "not_installed" instead of errored

### DIFF
--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -334,10 +334,10 @@ class PluginService
 
         $this->rollbackPluginMigrations($plugin);
 
+        $this->setStatus($plugin, PluginStatus::NotInstalled);
+
         if ($deleteFiles) {
             $this->deletePlugin($plugin);
-        } else {
-            $this->setStatus($plugin, PluginStatus::NotInstalled);
         }
 
         $this->buildAssets();


### PR DESCRIPTION
Followup for #2084

Failed installs should not be set to `Errored` because the plugin loader will try to load `Errored` plugins and if they load "successful" the plugin will be enabled again.