### PR TITLE
Move username sanitization to model and make it less strict

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -198,7 +198,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         });
 
         static::saving(function (self $user) {
-            $user->email = mb_strtolower($user->email);
+            $user->username = str($user->username)->lower()->toString();
+            $user->email = str($user->email)->lower()->toString();
         });
 
         static::deleting(function (self $user) {

--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -49,12 +49,6 @@ class UserCreationService
             $data['username'] = str($data['email'])->before('@')->toString() . Str::random(3);
         }
 
-        $data['username'] = str($data['username'])
-            ->replace(['.', '-'], '')
-            ->ascii()
-            ->substr(0, 64)
-            ->toString();
-
         /** @var User $user */
         $user = User::query()->forceCreate(array_merge($data, [
             'uuid' => Uuid::uuid4()->toString(),


### PR DESCRIPTION
Closes #2138

**Before:**
Backend silently removed `.` and `-` from username, made it lowercase and max length was 64.
Frontend did not check these restrictions.

**Now:**
Username is only made lowercase. (to allow case insensitive login) `.` and `-` are allowed. (will cause _no_ problems with sftp)
Frontend and backend limits for max length match.