### PR TITLE
Strip quotes from .env values in Docker entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,8 +2,13 @@
 # check for .env file or symlink and generate app keys if missing
 if [ -f /var/www/html/.env ]; then
   echo "external vars exist."
-  # load specific env vars from .env used in the entrypoint and they are not already set
-  for VAR in "APP_KEY" "APP_INSTALLED" "DB_CONNECTION" "DB_HOST" "DB_PORT"; do if ! (printenv | grep -q ${VAR}); then export $(grep ${VAR} .env | grep -ve "^#"); fi; done
+  # load specific env vars from .env used in the entrypoint if they are not already set
+  for VAR in "APP_KEY" "APP_INSTALLED" "DB_CONNECTION" "DB_HOST" "DB_PORT"; do
+    if ! (printenv | grep -q "^${VAR}="); then
+      VAL=$(grep "^${VAR}=" .env | grep -ve "^#" | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
+      if [ -n "$VAL" ]; then export "${VAR}=${VAL}"; fi
+    fi
+  done
 else
   echo "external vars don't exist."
   # webroot .env is symlinked to this path

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ if [ -f /var/www/html/.env ]; then
   # load specific env vars from .env used in the entrypoint if they are not already set
   for VAR in "APP_KEY" "APP_INSTALLED" "DB_CONNECTION" "DB_HOST" "DB_PORT"; do
     if ! (printenv | grep -q "^${VAR}="); then
-      VAL=$(grep "^${VAR}=" .env | grep -ve "^#" | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
+      VAL=$(grep "^${VAR}=" /var/www/html/.env | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")
       if [ -n "$VAL" ]; then export "${VAR}=${VAL}"; fi
     fi
   done


### PR DESCRIPTION
The previous grep+export approach passed surrounding quotes literally into environment variables, causing nc to fail with bad address errors when DB_HOST or DB_PORT were quoted in .env files.

Fixes #2132