### PR TITLE
Implement flexible caching for node statuses

### DIFF
--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -358,7 +358,7 @@ class Node extends Model implements Validatable
             'disk_used' => 0,
         ];
 
-        return cache()->remember("nodes.$this->id.statistics", now()->addSeconds(360), function () use ($default) {
+        return cache()->flexible("nodes.$this->id.statistics", [5, 30], function () use ($default) {
             try {
 
                 $data = Http::daemon($this)


### PR DESCRIPTION
Switches from cache()->remember() with a 360s TTL to cache()->flexible() with [5, 30]. Node stats are now fresh every 5s and refresh in the background, so the Livewire polling charts actually update in real time.

Fixes #2046

*Use stale-while-revalidate caching for node statistics*