### PR TITLE
Fix Egg Feature modals not working

### DIFF
--- a/app/Filament/Server/Pages/Console.php
+++ b/app/Filament/Server/Pages/Console.php
@@ -78,11 +78,15 @@ class Console extends Page
         $feature = data_get($data, 'key');
 
         $feature = $this->featureService->get($feature);
-        if (!$feature || $this->getMountedAction()) {
+        if (!$feature) {
             return;
         }
-        $this->mountAction($feature->getId());
-        sleep(2); // TODO find a better way
+
+        if ($this->getMountedAction()) {
+            $this->replaceMountedAction($feature->getId());
+        } else {
+            $this->mountAction($feature->getId());
+        }
     }
 
     public function getWidgetData(): array


### PR DESCRIPTION
Replace the blocking check that silently dropped second feature modals with Filament's replaceMountedAction() which atomically swaps modals. Also removes the sleep(2) hack that blocked PHP execution.

Fixes #1729