### PR TITLE
Implement single file move to support Unix mv semantics (#1984)

### DIFF
--- a/app/Filament/Server/Resources/Files/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/Files/Pages/ListFiles.php
@@ -209,16 +209,18 @@ class ListFiles extends ListRecords
                                 ->required()
                                 ->live(),
                             TextEntry::make('new_location')
-                                ->state(fn (Get $get, File $file) => resolve_path(join_paths($this->path, $get('location') ?? '/', $file->name))),
+                                ->state(fn (Get $get, File $file) => resolve_path(join_paths($this->path, str_ends_with($get('location') ?? '/', '/') ? join_paths($get('location') ?? '/', $file->name) : $get('location') ?? '/'))),
                         ])
                         ->action(function ($data, File $file) {
                             $location = $data['location'];
-                            $files = [['to' => join_paths($location, $file->name), 'from' => $file->name]];
+                            $endsWithSlash = str_ends_with($location, '/');
+                            $to = $endsWithSlash ? join_paths($location, $file->name) : $location;
+                            $files = [['to' => $to, 'from' => $file->name]];
 
                             $this->getDaemonFileRepository()->renameFiles($this->path, $files);
 
                             $oldLocation = join_paths($this->path, $file->name);
-                            $newLocation = resolve_path(join_paths($this->path, $location, $file->name));
+                            $newLocation = resolve_path(join_paths($this->path, $to));
 
                             Activity::event('server:file.rename')
                                 ->property('directory', $this->path)


### PR DESCRIPTION
Use trailing slash convention: destination ending with `/` keeps the original filename (move to directory), otherwise the destination is used as the full path (rename + move).

Resolves #1984 