### PR TITLE
Clarify OAuth error when provider account has no linked email

### DIFF
--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -74,7 +74,7 @@ class OAuthController extends Controller
         $email = $oauthUser->getEmail();
 
         if (!$email) {
-            return $this->errorRedirect();
+            return $this->errorRedirect('No email was linked to your account on the OAuth provider.');
         }
 
         $user = User::whereEmail($email)->first();


### PR DESCRIPTION
Fixes #2137 