### PR TITLE
Fix node FQDN validation showing banned values as valid (#1769)

### DIFF
--- a/app/Filament/Admin/Resources/Nodes/Pages/CreateNode.php
+++ b/app/Filament/Admin/Resources/Nodes/Pages/CreateNode.php
@@ -113,6 +113,12 @@ class CreateNode extends CreateRecord
                                 return;
                             }
 
+                            if (in_array(strtolower($state), Node::BANNED_FQDNS)) {
+                                $set('dns', false);
+
+                                return;
+                            }
+
                             $ip = get_ip_from_hostname($state);
                             if ($ip) {
                                 $set('dns', true);

--- a/app/Filament/Admin/Resources/Nodes/Pages/EditNode.php
+++ b/app/Filament/Admin/Resources/Nodes/Pages/EditNode.php
@@ -174,6 +174,12 @@ class EditNode extends EditRecord
                                 return;
                             }
 
+                            if (in_array(strtolower($state), Node::BANNED_FQDNS)) {
+                                $set('dns', false);
+
+                                return;
+                            }
+
                             $ip = get_ip_from_hostname($state);
                             if ($ip) {
                                 $set('dns', true);

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Validation\Rule;
 use Illuminate\Support\Str;
 use Symfony\Component\Yaml\Yaml;
 
@@ -72,6 +73,8 @@ class Node extends Model implements Validatable
 
     public const DAEMON_TOKEN_LENGTH = 64;
 
+    public const BANNED_FQDNS = ['0.0.0.0', '127.0.0.1', 'localhost'];
+
     /**
      * The attributes excluded from the model's JSON form.
      */
@@ -95,7 +98,7 @@ class Node extends Model implements Validatable
         'name' => ['required', 'string', 'min:1', 'max:100'],
         'description' => ['string', 'nullable'],
         'public' => ['boolean'],
-        'fqdn' => ['required', 'string', 'notIn:0.0.0.0,127.0.0.1,localhost'],
+        'fqdn' => ['required', 'string'],
         'scheme' => ['required', 'string', 'in:http,https'],
         'behind_proxy' => ['boolean'],
         'memory' => ['required', 'numeric', 'min:0'],
@@ -113,6 +116,14 @@ class Node extends Model implements Validatable
         'upload_size' => ['int', 'min:1'],
         'tags' => ['array'],
     ];
+
+    public static function getRules(): array
+    {
+        $rules = static::$validationRules;
+        $rules['fqdn'][] = Rule::notIn(static::BANNED_FQDNS);
+
+        return $rules;
+    }
 
     /**
      * Default values for specific columns that are generally not changed on base installs.

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -17,8 +17,8 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Validation\Rule;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Symfony\Component\Yaml\Yaml;
 
 /**


### PR DESCRIPTION
Reject banned FQDNs (localhost, 127.0.0.1, 0.0.0.0) in the DNS check callback so the form shows a red indicator immediately, instead of misleadingly resolving localhost to 127.0.0.1 with a green checkmark. Extract banned values into a Node::BANNED_FQDNS constant for reuse.

Fixes #1769