### PR TITLE
fix: composer content hash

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee0e729079d522f013d1203a624a4765",
+    "content-hash": "15f89930db77693b2d692dbadf22fb9f",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",


### PR DESCRIPTION
There seems to be an issue with the composer hash for me when trying to build a nix derivation. Updating the composer content hash (`composer update --lock --no-install`) seems to resolve that issue.
This seems to have happened before (see #533). 