### PR TITLE
fix: composer not been installed in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ RUN apk add --no-cache \
     # required for installing plugins. Pulled from https://github.com/pelican-dev/panel/pull/2034
     zip unzip 7zip bzip2-dev yarn git
 
+# Copy composer binary for runtime plugin dependency management
+COPY --from=composer /usr/local/bin/composer /usr/local/bin/composer    
+
 COPY --chown=root:www-data --chmod=770 --from=composerbuild /build .
 COPY --chown=root:www-data --chmod=770 --from=yarnbuild /build/public ./public
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -73,6 +73,9 @@ RUN apk add --no-cache \
     # required for installing plugins. Pulled from https://github.com/pelican-dev/panel/pull/2034
     zip unzip 7zip bzip2-dev yarn git
 
+# Copy composer binary for runtime plugin dependency management
+COPY --from=composer /usr/local/bin/composer /usr/local/bin/composer    
+
 COPY --chown=root:www-data --chmod=770 --from=composerbuild /build .
 COPY --chown=root:www-data --chmod=770 --from=yarnbuild /build/public ./public
 


### PR DESCRIPTION
# Changes

- fix #2025
- Install composer on the final image, so plugins can install modules if needed
