### PR TITLE
Handle invalid svg icon in generic-oidc provider gracefully

### DIFF
--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -13,6 +13,8 @@ use App\Traits\Filament\CanCustomizeHeaderActions;
 use App\Traits\Filament\CanCustomizeHeaderWidgets;
 use App\Traits\Filament\CanCustomizeTabs;
 use BackedEnum;
+use BladeUI\Icons\Exceptions\SvgNotFound;
+use BladeUI\Icons\Factory as IconFactory;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -68,6 +70,8 @@ class Settings extends Page implements HasSchemas
 
     protected CaptchaService $captchaService;
 
+    protected IconFactory $iconFactory;
+
     /** @var array<mixed>|null */
     public ?array $data = [];
 
@@ -76,11 +80,12 @@ class Settings extends Page implements HasSchemas
         $this->form->fill();
     }
 
-    public function boot(OAuthService $oauthService, AvatarService $avatarService, CaptchaService $captchaService): void
+    public function boot(OAuthService $oauthService, AvatarService $avatarService, CaptchaService $captchaService, IconFactory $iconFactory): void
     {
         $this->oauthService = $oauthService;
         $this->avatarService = $avatarService;
         $this->captchaService = $captchaService;
+        $this->iconFactory = $iconFactory;
     }
 
     public static function canAccess(): bool
@@ -565,9 +570,18 @@ class Settings extends Page implements HasSchemas
         foreach ($oauthSchemas as $schema) {
             $key = $schema->getConfigKey();
 
+            $icon = $schema->getIcon();
+            if (is_string($icon)) {
+                try {
+                    $this->iconFactory->svg($icon);
+                } catch (SvgNotFound) {
+                    $icon = null;
+                }
+            }
+
             $formFields[] = Section::make($schema->getName())
                 ->columns(5)
-                ->icon($schema->getIcon() ?? TablerIcon::BrandOauth)
+                ->icon($icon ?? TablerIcon::BrandOauth)
                 ->collapsed(fn () => !$schema->isEnabled())
                 ->collapsible()
                 ->schema([

--- a/app/Filament/Pages/Auth/Login.php
+++ b/app/Filament/Pages/Auth/Login.php
@@ -4,6 +4,8 @@ namespace App\Filament\Pages\Auth;
 
 use App\Extensions\Captcha\CaptchaService;
 use App\Extensions\OAuth\OAuthService;
+use BladeUI\Icons\Exceptions\SvgNotFound;
+use BladeUI\Icons\Factory as IconFactory;
 use Filament\Actions\Action;
 use Filament\Auth\Pages\Login as BaseLogin;
 use Filament\Forms\Components\TextInput;
@@ -19,10 +21,13 @@ class Login extends BaseLogin
 
     protected CaptchaService $captchaService;
 
-    public function boot(OAuthService $oauthService, CaptchaService $captchaService): void
+    protected IconFactory $iconFactory;
+
+    public function boot(OAuthService $oauthService, CaptchaService $captchaService, IconFactory $iconFactory): void
     {
         $this->oauthService = $oauthService;
         $this->captchaService = $captchaService;
+        $this->iconFactory = $iconFactory;
     }
 
     public function form(Schema $schema): Schema
@@ -87,9 +92,18 @@ class Login extends BaseLogin
             $color = $schema->getHexColor();
             $color = is_string($color) ? Color::hex($color) : null;
 
+            $icon = $schema->getIcon();
+            if (is_string($icon)) {
+                try {
+                    $this->iconFactory->svg($icon);
+                } catch (SvgNotFound) {
+                    $icon = null;
+                }
+            }
+
             $actions[] = Action::make("oauth_$id")
                 ->label($schema->getName())
-                ->icon($schema->getIcon())
+                ->icon($icon)
                 ->color($color)
                 ->url(route('auth.oauth.redirect', ['driver' => $id], false));
         }


### PR DESCRIPTION
When an invalid SVG icon name is configured for a generic-oidc provider, the login page crashes with a SvgNotFound exception making the dashboard inaccessible.

Fixes #2210