### PR TITLE
Docker: chown composer.json and composer.lock for plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,7 @@ RUN mkdir -p /pelican-data/storage /pelican-data/plugins /var/run/supervisord \
 # Allow www-data write permissions where necessary
     && chown -R www-data: /pelican-data .env ./storage ./plugins ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R 770 /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \
-    && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/
-
+    && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/ /var/www/html/composer.json /var/www/html/composer.lock
 # Configure Supervisor
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/Caddyfile /etc/caddy/Caddyfile

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -91,7 +91,7 @@ RUN mkdir -p /pelican-data/storage /pelican-data/plugins /var/run/supervisord \
 # Allow www-data write permissions where necessary
     && chown -R www-data: /pelican-data .env ./storage ./plugins ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R 770 /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \
-    && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/
+    && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/ /var/www/html/composer.json /var/www/html/composer.lock
 
 # Configure Supervisor
 COPY docker/supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
This pull request updates file permissions in both the production (`Dockerfile`) and development (`Dockerfile.dev`) Docker images to ensure that the `www-data` user has ownership of the Composer files. This change helps prevent permission issues when running Composer commands inside the container.

Fixes #2219