### PR TITLE
Convert YAML boolean defaults to strings

### DIFF
--- a/app/Services/Eggs/Sharing/EggImporterService.php
+++ b/app/Services/Eggs/Sharing/EggImporterService.php
@@ -189,6 +189,18 @@ class EggImporterService
             }
         }
 
+        // Convert YAML booleans to strings to prevent Laravel from converting them to 1/0
+        // when saving to TEXT field. Required for validation rules like "in:true,false".
+        if (isset($parsed['variables'])) {
+            $parsed['variables'] = array_map(function ($variable) {
+                if (isset($variable['default_value']) && is_bool($variable['default_value'])) {
+                    $variable['default_value'] = $variable['default_value'] ? 'true' : 'false';
+                }
+
+                return $variable;
+            }, $parsed['variables']);
+        }
+
         // Reserved env var name handling
         [$forbidden, $allowed] = collect($parsed['variables'])
             ->map(fn ($variable) => array_merge(


### PR DESCRIPTION
**Problem:**
When importing eggs from YAML format, boolean values (true/false) were being converted to integers (1/0) when saved to the database. This broke validation rules like in:true,false that require exact string matches.

**Root Cause:**
Symfony YAML parser correctly converts YAML booleans to PHP booleans
Laravel automatically converts PHP booleans to integers when saving to TEXT fields
Result: default_value: true → stored as "1" instead of "true"

**Solution:**
Added explicit conversion of boolean values to their string representations ("true"/"false") in EggImporterService::parse() before saving to the database.

**Impact:**
Variables with rules: `in:true,false` now work correctly after YAML import

Backwards compatible: quoted boolean strings in YAML remain unchanged
Only affects actual YAML boolean values (unquoted true/false)
