### PR TITLE
Fix stock egg UUID migration

### DIFF
--- a/database/migrations/2026_01_14_221937_convert_stock_egg_uuids.php
+++ b/database/migrations/2026_01_14_221937_convert_stock_egg_uuids.php
@@ -8,20 +8,20 @@ return new class extends Migration
     {
         $mappings = [
             // Forge Minecraft
-            'ed072427-f209-4603-875c-f540c6dd5a65' => [
-                'new_uuid' => 'd6018085-eecc-42bf-bf8c-51ea45a69ace',
+            'd6018085-eecc-42bf-bf8c-51ea45a69ace' => [
+                'new_uuid' => 'ed072427-f209-4603-875c-f540c6dd5a65',
                 'new_update_url' => 'https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/forge/egg-forge-minecraft.yaml',
             ],
 
             // Paper
-            '5da37ef6-58da-4169-90a6-e683e1721247' => [
-                'new_uuid' => '150956be-4164-4086-9057-631ae95505e9',
+            '150956be-4164-4086-9057-631ae95505e9' => [
+                'new_uuid' => '5da37ef6-58da-4169-90a6-e683e1721247',
                 'new_update_url' => 'https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/paper/egg-paper.yaml',
             ],
 
             // Garrys Mod
-            '60ef81d4-30a2-4d98-ab64-f59c69e2f915' => [
-                'new_uuid' => 'c0b2f96a-f753-4d82-a73e-6e5be2bbadd5',
+            'c0b2f96a-f753-4d82-a73e-6e5be2bbadd5' => [
+                'new_uuid' => '60ef81d4-30a2-4d98-ab64-f59c69e2f915',
                 'new_update_url' => 'https://raw.githubusercontent.com/pelican-eggs/games-steamcmd/refs/heads/main/gmod/egg-garrys-mod.yaml',
             ],
         ];

--- a/database/migrations/2026_01_14_221937_convert_stock_egg_uuids.php
+++ b/database/migrations/2026_01_14_221937_convert_stock_egg_uuids.php
@@ -27,10 +27,16 @@ return new class extends Migration
         ];
 
         foreach ($mappings as $oldUuid => $newData) {
-            DB::table('eggs')->where('uuid', $oldUuid)->update([
-                'uuid' => $newData['new_uuid'],
-                'update_url' => $newData['new_update_url'],
-            ]);
+            if (DB::table('eggs')->where('uuid', $newData['new_uuid'])->exists()) {
+                DB::table('eggs')->where('uuid', $newData['new_uuid'])->update([
+                    'update_url' => $newData['new_update_url'],
+                ]);
+            } else {
+                DB::table('eggs')->where('uuid', $oldUuid)->update([
+                    'uuid' => $newData['new_uuid'],
+                    'update_url' => $newData['new_update_url'],
+                ]);
+            }
         }
     }
 


### PR DESCRIPTION
We messed up the UUIDs of the former stock eggs and used the former stock egg UUID instead of the UUID of the existing egg. This means the migration is wrong.

I also added an additional check to make sure the migration doesn't fail if you have both egg versions installed.