### PR TITLE
Fix PATCH /api/application/nodes returning 500 due to null timestamps

### DIFF
--- a/app/Services/Nodes/NodeUpdateService.php
+++ b/app/Services/Nodes/NodeUpdateService.php
@@ -40,6 +40,7 @@ class NodeUpdateService
             /** @var Node $updated */
             $updated = $node->replicate();
             $updated->exists = true;
+            $data = array_merge($data, ['created_at' => $node->created_at, 'updated_at' => now()]);
             $updated->forceFill($data)->save();
             try {
                 $node->fqdn = $updated->fqdn;


### PR DESCRIPTION
The `NodeUpdateService` uses `replicate()` to create a copy of the node model before updating it. `replicate()` strips timestamp fields, and after `forceFill()->save()`, the in-memory model still has null values for created_at and updated_at. When the `NodeTransformer` calls `formatTimestamp()` on these null values, it triggers a TypeError because the method expects a non-nullable string.

Adding `refresh()` after `save()` reloads the model from the database, ensuring timestamps are properly populated before the response is serialized.

This was discovered when attempting to programmatically update nodes using the API, which reliably reproduces the following error:

```
App\Transformers\Api\Application\BaseTransformer::formatTimestamp(): Argument #1 ($timestamp) must be of type string, null given, called in /var/www/pelican/app/Transformers/Api/Application/NodeTransformer.php on line 36 {"userId":2,"exception":"[object] (TypeError(code: 0): App\\Transformers\\Api\\Application\\BaseTransformer::formatTimestamp(): Argument #1 ($timestamp) must be of type string, null given, called in /var/www/pelican/app/Transformers/Api/Application/NodeTransformer.php on line 36 at /var/www/pelican/app/Transformers/Api/Application/BaseTransformer.php:109)
```