### PR TITLE
Feature: Add support for user-configurable egg/nests index file.

### DIFF
--- a/app/Console/Commands/Egg/UpdateEggIndexCommand.php
+++ b/app/Console/Commands/Egg/UpdateEggIndexCommand.php
@@ -13,7 +13,7 @@ class UpdateEggIndexCommand extends Command
     public function handle(): int
     {
         try {
-            $data = Http::timeout(5)->connectTimeout(1)->get(config('panel.egg.index_url'))->throw()->json();
+            $data = Http::timeout(5)->connectTimeout(1)->get(config('panel.egg.nest_url'))->throw()->json();
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
 

--- a/app/Console/Commands/Egg/UpdateEggIndexCommand.php
+++ b/app/Console/Commands/Egg/UpdateEggIndexCommand.php
@@ -13,7 +13,7 @@ class UpdateEggIndexCommand extends Command
     public function handle(): int
     {
         try {
-            $data = Http::timeout(5)->connectTimeout(1)->get('https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json')->throw()->json();
+            $data = Http::timeout(5)->connectTimeout(1)->get(config('panel.egg.index_url'))->throw()->json();
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
 

--- a/app/Console/Commands/Egg/UpdateEggIndexCommand.php
+++ b/app/Console/Commands/Egg/UpdateEggIndexCommand.php
@@ -13,7 +13,7 @@ class UpdateEggIndexCommand extends Command
     public function handle(): int
     {
         try {
-            $data = Http::timeout(5)->connectTimeout(1)->get(config('panel.egg.nest_url'))->throw()->json();
+            $data = Http::timeout(5)->connectTimeout(1)->get(config('panel.cdn.egg_index_url'))->throw()->json();
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
 

--- a/config/panel.php
+++ b/config/panel.php
@@ -18,7 +18,7 @@ return [
 
     'cdn' => [
         'cache_time' => 60,
-        'egg_index_url' => env('EGG_INDEX_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
+        'egg_index_url' => env('PANEL_EGG_INDEX_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
     ],
 
     'client_features' => [

--- a/config/panel.php
+++ b/config/panel.php
@@ -76,6 +76,6 @@ return [
     ],
 
     'egg' => [
-        'index_url' => env('PANEL_EGG_INDEX_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
+        'nest_url' => env('PANEL_EGG_NEST_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
     ]
 ];

--- a/config/panel.php
+++ b/config/panel.php
@@ -74,4 +74,8 @@ return [
         'dev_mode' => env('PANEL_PLUGIN_DEV_MODE', false),
         'max_import_size' => env('PANEL_PLUGIN_MAX_IMPORT_SIZE', 1024 * 1024 * 100),
     ],
+
+    'egg' => [
+        'index_url' => env('PANEL_EGG_INDEX_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
+    ]
 ];

--- a/config/panel.php
+++ b/config/panel.php
@@ -77,5 +77,5 @@ return [
 
     'egg' => [
         'nest_url' => env('PANEL_EGG_NEST_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
-    ]
+    ],
 ];

--- a/config/panel.php
+++ b/config/panel.php
@@ -18,6 +18,7 @@ return [
 
     'cdn' => [
         'cache_time' => 60,
+        'egg_index_url' => env('EGG_INDEX_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
     ],
 
     'client_features' => [
@@ -73,9 +74,5 @@ return [
     'plugin' => [
         'dev_mode' => env('PANEL_PLUGIN_DEV_MODE', false),
         'max_import_size' => env('PANEL_PLUGIN_MAX_IMPORT_SIZE', 1024 * 1024 * 100),
-    ],
-
-    'egg' => [
-        'nest_url' => env('PANEL_EGG_NEST_URL', 'https://raw.githubusercontent.com/pelican-eggs/pelican-eggs.github.io/refs/heads/main/content/pelican.json'),
     ],
 ];


### PR DESCRIPTION
Bit of a feature suggestion here. Noticed the URL used to build up the list of suggested official eggs was hardcoded. This pull request moves the URL into the application config with an optional environment override.

We have a number of custom egg configs that we want to offer to our admins. Copy pasting URLs for those was getting a little tedious, especially if one is accidentally deleted and you don't have the original URL handy.

This should address that, plus open up for users to make eggs discoverable through the import menu, or limit which nests should appear in the menu.

Not sure what you have on the roadmap, but I'd be happy to work on a follow-up to this where nests can be merged with a user-provided URL instead of replaced outright.