### PR TITLE
Catch icon exception when importing egg

### DIFF
--- a/app/Models/Traits/HasIcon.php
+++ b/app/Models/Traits/HasIcon.php
@@ -49,7 +49,7 @@ trait HasIcon
         };
 
         if (is_null($normalizedExtension)) {
-            throw new Exception(trans('admin/egg.import.unknown_extension'));
+            throw new Exception(trans('admin/egg.import.unknown_extension', ['extension' => $extension]));
         }
 
         $fileName = static::getIconStoragePath() . "/$this->uuid.$normalizedExtension";

--- a/app/Services/Eggs/Sharing/EggImporterService.php
+++ b/app/Services/Eggs/Sharing/EggImporterService.php
@@ -6,6 +6,7 @@ use App\Enums\EggFormat;
 use App\Exceptions\Service\InvalidFileUploadException;
 use App\Models\Egg;
 use App\Models\EggVariable;
+use Exception;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
@@ -268,11 +269,15 @@ class EggImporterService
             return;
         }
 
-        $extension = strtolower($matches[1]);
-        $data = base64_decode($matches[2]);
+        try {
+            $extension = strtolower($matches[1]);
+            $data = base64_decode($matches[2]);
 
-        if ($data) {
-            $egg->writeIcon($extension, $data);
+            if ($data) {
+                $egg->writeIcon($extension, $data);
+            }
+        } catch (Exception $exception) {
+            report($exception);
         }
     }
 

--- a/lang/en/admin/egg.php
+++ b/lang/en/admin/egg.php
@@ -30,7 +30,7 @@ return [
         'no_local_ip' => 'Local IP Addresses are not allowed',
         'unsupported_format' => 'Unsupported Format. Supported Formats: :formats',
         'invalid_url' => 'The provided URL is invalid',
-        'unknown_extension' => 'Unknown icon extension',
+        'unknown_extension' => 'Unknown icon extension (:extension)',
         'could_not_write' => 'Could not write icon to disk',
         'icon_deleted' => 'Icon Deleted',
         'no_icon' => 'No Icon Provided',


### PR DESCRIPTION
Small followup for #2281

Previously the whole egg import would fail when the icon was wrong/invalid. Now it will simply skip the icon and import the egg normally.