### PR TITLE
Correctly store falsy startup variable values

### DIFF
--- a/app/Filament/Components/Forms/Fields/StartupVariable.php
+++ b/app/Filament/Components/Forms/Fields/StartupVariable.php
@@ -49,7 +49,7 @@ class StartupVariable extends Field
 
         $this->hintIcon(TablerIcon::Code, fn (StartupVariable $component) => implode('|', $component->getVariableRules()));
 
-        $this->helperText(fn (StartupVariable $component) => !$component->getVariableDesc() ? '—' : $component->getVariableDesc());
+        $this->helperText(fn (StartupVariable $component) => $component->getVariableDesc());
 
         $this->rules(fn (StartupVariable $component) => $component->getVariableRules());
 
@@ -70,7 +70,7 @@ class StartupVariable extends Field
             ],
             StartupVariableType::Toggle => [
                 ...parent::getDefaultStateCasts(),
-                new BooleanStateCast(false),
+                new BooleanStateCast(false, true),
             ],
             default => parent::getDefaultStateCasts()
         };

--- a/app/Filament/Server/Pages/Startup.php
+++ b/app/Filament/Server/Pages/Startup.php
@@ -149,10 +149,14 @@ class Startup extends ServerFormPage
         return parent::canAccess() && user()?->can(SubuserPermission::StartupRead, Filament::getTenant());
     }
 
-    public function update(?string $state, ServerVariable $serverVariable): void
+    public function update(null|string|bool $state, ServerVariable $serverVariable): void
     {
         if (!$serverVariable->variable->user_editable) {
             return;
+        }
+
+        if (is_bool($state)) {
+            $state = (int) $state;
         }
 
         $original = $serverVariable->variable_value;
@@ -185,14 +189,14 @@ class Startup extends ServerFormPage
                     ->property([
                         'variable' => $serverVariable->variable->env_variable,
                         'old' => $original,
-                        'new' => $state,
+                        'new' => (string) $state,
                     ])
                     ->log();
             }
 
             Notification::make()
                 ->title(trans('server/startup.update', ['variable' => $serverVariable->variable->name]))
-                ->body(fn () => $original . ' -> ' . $state)
+                ->body(fn () => $original . ' -> ' . ((string) $state))
                 ->success()
                 ->send();
         } catch (Exception $e) {

--- a/app/Filament/Server/Pages/Startup.php
+++ b/app/Filament/Server/Pages/Startup.php
@@ -156,7 +156,7 @@ class Startup extends ServerFormPage
         }
 
         if (is_bool($state)) {
-            $state = (int) $state;
+            $state = $state ? '1' : '0';
         }
 
         $original = $serverVariable->variable_value;
@@ -189,14 +189,14 @@ class Startup extends ServerFormPage
                     ->property([
                         'variable' => $serverVariable->variable->env_variable,
                         'old' => $original,
-                        'new' => (string) $state,
+                        'new' => $state,
                     ])
                     ->log();
             }
 
             Notification::make()
                 ->title(trans('server/startup.update', ['variable' => $serverVariable->variable->name]))
-                ->body(fn () => $original . ' -> ' . ((string) $state))
+                ->body(fn () => $original . ' -> ' . $state)
                 ->success()
                 ->send();
         } catch (Exception $e) {


### PR DESCRIPTION
Closes #2302

Fixes both saving `false` and the notification displaying it as empty value.