### PR TITLE
Fix TagsFilter undefined array key on PHP 8.5

### DIFF
--- a/app/Filament/Components/Tables/Filters/TagsFilter.php
+++ b/app/Filament/Components/Tables/Filters/TagsFilter.php
@@ -21,9 +21,9 @@ class TagsFilter extends BaseFilter
     {
         parent::setUp();
 
-        $this->query(fn (Builder $query, array $data) => $query->when($data['tag'], fn (Builder $query, $tag) => $query->whereJsonContains('tags', $tag)));
+        $this->query(fn (Builder $query, array $data) => $query->when($data['tag'] ?? null, fn (Builder $query, $tag) => $query->whereJsonContains('tags', $tag)));
 
-        $this->indicateUsing(fn (array $data) => $data['tag'] ? 'Tag: ' . $data['tag'] : null);
+        $this->indicateUsing(fn (array $data) => ($data['tag'] ?? null) ? 'Tag: ' . $data['tag'] : null);
 
         $this->resetState(['tag' => null]);
 


### PR DESCRIPTION
## Summary

Visiting `/admin/eggs` on PHP 8.5 throws `ErrorException: Undefined array key "tag"` from `app/Filament/Components/Tables/Filters/TagsFilter.php`. Lines 24 and 26 access `\$data['tag']` directly; the key isn't present until `resetState(['tag' => null])` is consumed by user interaction, so the first render hits the closures with `\$data = []`. PHP 8.x emits an `Undefined array key` warning, which Laravel's error handler converts to an exception.

Fix replaces both accesses with the null-coalescing form `\$data['tag'] ?? null`.

Re-opens the discussion from #2060 — same root cause, but the original reporter was on canary without a PHP version cited and the maintainer couldn't reproduce. PHP 8.5 reliably triggers it.

## Test plan

- [x] PHP 8.5.5: `/admin/eggs` 500s before this patch, renders cleanly after.
- [x] `vendor/bin/pint app/Filament/Components/Tables/Filters/TagsFilter.php` passes.
- [ ] Verified the filter still works once activated (selecting a tag still queries `whereJsonContains` correctly).