### PR TITLE
Add option to disable password login

### DIFF
--- a/app/Filament/Pages/Auth/Login.php
+++ b/app/Filament/Pages/Auth/Login.php
@@ -13,6 +13,7 @@ use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
 use Filament\Support\Colors\Color;
+use Filament\Support\Enums\Alignment;
 use Illuminate\Validation\ValidationException;
 
 class Login extends BaseLogin
@@ -32,6 +33,12 @@ class Login extends BaseLogin
 
     public function form(Schema $schema): Schema
     {
+        if (config('auth.disable_password_login', false)) {
+            return $schema->components([
+                $this->getOAuthFormComponent(),
+            ]);
+        }
+
         $components = [
             $this->getLoginFormComponent(),
             $this->getPasswordFormComponent(),
@@ -108,11 +115,22 @@ class Login extends BaseLogin
                 ->url(route('auth.oauth.redirect', ['driver' => $id], false));
         }
 
-        return Actions::make($actions);
+        return Actions::make($actions)->alignment(fn () => config('auth.disable_password_login', false) ? Alignment::Center : null);
+    }
+
+    protected function getFormActions(): array
+    {
+        return config('auth.disable_password_login', false) ? [] : parent::getFormActions();
     }
 
     protected function getCredentialsFromFormData(array $data): array
     {
+        if (config('auth.disable_password_login', false)) {
+            throw ValidationException::withMessages([
+                'data.login' => trans('auth.password_login_disabled'),
+            ]);
+        }
+
         $loginType = filter_var($data['login'], FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
 
         return [

--- a/config/auth.php
+++ b/config/auth.php
@@ -2,6 +2,8 @@
 
 return [
 
+    'disable_password_login' => env('AUTH_DISABLE_PASSWORD_LOGIN', false),
+
     'lockout' => [
         'time' => 2,
         'attempts' => 3,

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -20,5 +20,6 @@ return [
     'password' => 'The provided password is incorrect.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
     '2fa_must_be_enabled' => 'The administrator has required that 2-Factor Authentication must be enabled for your account in order to use the Panel.',
+    'password_login_disabled' => 'Password login is disabled. Please use an OAuth provider to sign in.',
 
 ];


### PR DESCRIPTION
This is step 1 (of many) in a series of PRs to allow Pelican Panel and https://github.com/pelican-dev/plugins/tree/main/generic-oidc-providers to be operational fully declaratively, using just external OIDC authentication.

This PR adds support to optionally hide the password log in fields.