### PR TITLE
Fix trailing slash of untold torment and suffering

### DIFF
--- a/app/Filament/Server/Resources/Files/Pages/EditFiles.php
+++ b/app/Filament/Server/Resources/Files/Pages/EditFiles.php
@@ -261,7 +261,7 @@ class EditFiles extends Page
 
     public static function getUrl(array $parameters = [], bool $isAbsolute = true, ?string $panel = null, ?Model $tenant = null, bool $shouldGuessMissingParameters = false, ?string $configuration = null): string
     {
-        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration) . '/';
+        return parent::getUrl($parameters, $isAbsolute, $panel, $tenant, $shouldGuessMissingParameters, $configuration);
     }
 
     public static function route(string $path): PageRegistration


### PR DESCRIPTION
When Pelican is deployed behind a reverse proxy (e.g., Traefik, nginx) that terminates TLS and forwards plain HTTP to Apache, navigating to the file editor triggers a mixed content block in the browser.

Why? `EditFiles::getUrl()` appends a trailing `/` to the URL. The `.htaccess` rewrite rule then strips it with a 301 Redirect. When Apache constructs the redirect URL, it uses the scheme of the incoming connection (plain `http://`), not the external-facing scheme. The browser sees a redirect from `https://` to `http://` and blocks it as mixed active content.

The fix simply removes the trailing slash concatenation. The redirect was always a no-op from the user's perspective (append slash, immediately redirect to remove it), and Laravel's front controller handles routing regardless of trailing slashes.

I have run out of hairs to pull out debugging this.

Possibly relevant to #1685.