### PR TITLE
restore daemon error surface for wings 4xx

### DIFF
--- a/app/Repositories/Daemon/DaemonFileRepository.php
+++ b/app/Repositories/Daemon/DaemonFileRepository.php
@@ -7,6 +7,7 @@ use App\Exceptions\Repository\FileExistsException;
 use App\Exceptions\Repository\FileNotEditableException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 
 class DaemonFileRepository extends DaemonRepository
@@ -22,21 +23,27 @@ class DaemonFileRepository extends DaemonRepository
      */
     public function getContent(string $path, ?int $notLargerThan = null): string
     {
-        $response = $this->getHttpClient()->get("/api/servers/{$this->server->uuid}/files/contents",
-            ['file' => $path]
-        );
+        try {
+            $response = $this->getHttpClient()->get("/api/servers/{$this->server->uuid}/files/contents",
+                ['file' => $path]
+            );
+        } catch (RequestException $exception) {
+            $status = $exception->response->status();
+
+            if ($status === 400) {
+                throw new FileNotEditableException();
+            }
+
+            if ($status === 404) {
+                throw new FileNotFoundException();
+            }
+
+            throw $exception;
+        }
 
         $length = $response->header('Content-Length');
         if ($notLargerThan && $length > $notLargerThan) {
             throw new FileSizeTooLargeException();
-        }
-
-        if ($response->status() === 400) {
-            throw new FileNotEditableException();
-        }
-
-        if ($response->status() === 404) {
-            throw new FileNotFoundException();
         }
 
         return $response;
@@ -51,16 +58,18 @@ class DaemonFileRepository extends DaemonRepository
      */
     public function putContent(string $path, string $content): Response
     {
-        $response = $this->getHttpClient()
-            ->withQueryParameters(['file' => $path])
-            ->withBody($content)
-            ->post("/api/servers/{$this->server->uuid}/files/write");
+        try {
+            return $this->getHttpClient()
+                ->withQueryParameters(['file' => $path])
+                ->withBody($content)
+                ->post("/api/servers/{$this->server->uuid}/files/write");
+        } catch (RequestException $exception) {
+            if ($exception->response->status() === 400) {
+                throw new FileExistsException();
+            }
 
-        if ($response->status() === 400) {
-            throw new FileExistsException();
+            throw $exception;
         }
-
-        return $response;
     }
 
     /**
@@ -85,18 +94,20 @@ class DaemonFileRepository extends DaemonRepository
      */
     public function createDirectory(string $name, string $path): Response
     {
-        $response = $this->getHttpClient()->post("/api/servers/{$this->server->uuid}/files/create-directory",
-            [
-                'name' => $name,
-                'path' => $path,
-            ]
-        );
+        try {
+            return $this->getHttpClient()->post("/api/servers/{$this->server->uuid}/files/create-directory",
+                [
+                    'name' => $name,
+                    'path' => $path,
+                ]
+            );
+        } catch (RequestException $exception) {
+            if ($exception->response->status() === 400) {
+                throw new FileExistsException();
+            }
 
-        if ($response->status() === 400) {
-            throw new FileExistsException();
+            throw $exception;
         }
-
-        return $response;
     }
 
     /**

--- a/app/Repositories/Daemon/DaemonRepository.php
+++ b/app/Repositories/Daemon/DaemonRepository.php
@@ -57,9 +57,6 @@ abstract class DaemonRepository
         if (is_bool($condition)) {
             return $condition;
         }
-        if ($condition->clientError()) {
-            return false;
-        }
 
         $header = $condition->header('User-Agent');
         if (


### PR DESCRIPTION
follow-up to #1417 which introduced a regression.

before:
the clientError short-circuit returns false on any 4xx error, so throwIf skips $response->throw(). the fire-and-forget callers (delete, sync, reinstall, cancelTransfer, create) return void on 404 against wings beta25. this was identified as it matched reports from our users of "server stuck installing", "config not applied with no error", "delete succeeded but container still running". 

additionally getSystemInformation throws a misleading "is not Pelican Wings !" on 4xx, the body-shape check fires on the error body.

change:
drop the short-circuit. file repo's three post-call status checks move into RequestException catches so the typed exceptions still fire.

after:
RequestException throws on 4xx like 5xx already did. previously silent 4xx now surface as filament toasts in the UI. file-manager UX from #1417 unchanged. getSystemInformation throws RequestException with the actual status.