### PR TITLE
Fix multi file upload

### DIFF
--- a/app/Filament/Server/Resources/Files/Pages/ListFiles.php
+++ b/app/Filament/Server/Resources/Files/Pages/ListFiles.php
@@ -16,10 +16,8 @@ use App\Livewire\AlertBanner;
 use App\Models\File;
 use App\Models\Server;
 use App\Repositories\Daemon\DaemonFileRepository;
-use App\Services\Nodes\NodeJWTService;
 use App\Traits\Filament\CanCustomizeHeaderActions;
 use App\Traits\Filament\CanCustomizeHeaderWidgets;
-use Carbon\CarbonImmutable;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -614,28 +612,6 @@ class ListFiles extends ListRecords
             7 => ['read', 'write', 'execute'],
             default => [],
         };
-    }
-
-    public function getUploadUrl(NodeJWTService $jwtService): string
-    {
-        /** @var Server $server */
-        $server = Filament::getTenant();
-
-        if (!user()?->can(SubuserPermission::FileCreate, $server)) {
-            abort(403, 'You do not have permission to upload files.');
-        }
-
-        $token = $jwtService
-            ->setExpiresAt(CarbonImmutable::now()->addMinutes(15))
-            ->setUser(user())
-            ->setClaims(['server_uuid' => $server->uuid])
-            ->handle($server->node, user()->id . $server->uuid);
-
-        return sprintf(
-            '%s/upload/file?token=%s',
-            $server->node->getConnectionAddress(),
-            $token->toString()
-        );
     }
 
     public function getUploadSizeLimit(): int

--- a/resources/views/filament/server/pages/file-upload.blade.php
+++ b/resources/views/filament/server/pages/file-upload.blade.php
@@ -1,10 +1,20 @@
 <div
     x-data="{
+    serverUuid: @js(\Filament\Facades\Filament::getTenant()->uuid),
     isUploading: false,
     uploadQueue: [],
     currentFileIndex: 0,
     totalFiles: 0,
     autoCloseTimer: 1000,
+
+    async fetchUploadUrl() {
+        const r = await fetch(`/api/client/servers/${this.serverUuid}/files/upload`, {
+            headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+            credentials: 'same-origin',
+        });
+        if (!r.ok) throw new Error(`upload url request failed (${r.status})`);
+        return (await r.json()).attributes.url;
+    },
 
     async extractFilesFromItems(items) {
         const filesWithPaths = [];
@@ -210,7 +220,7 @@
         const fileData = this.uploadQueue[index];
         fileData.status = 'uploading';
         try {
-            const uploadUrl = await $wire.getUploadUrl();
+            const uploadUrl = await this.fetchUploadUrl();
             const url = new URL(uploadUrl);
             let basePath = @js($this->path);
 

--- a/resources/views/filament/server/pages/list-files.blade.php
+++ b/resources/views/filament/server/pages/list-files.blade.php
@@ -2,6 +2,7 @@
     <div
         x-data="
         {
+            serverUuid: @js(\Filament\Facades\Filament::getTenant()->uuid),
             isDragging: false,
             dragCounter: 0,
             isUploading: false,
@@ -9,6 +10,15 @@
             currentFileIndex: 0,
             totalFiles: 0,
             autoCloseTimer: 1000,
+
+            async fetchUploadUrl() {
+                const r = await fetch(`/api/client/servers/${this.serverUuid}/files/upload`, {
+                    headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                    credentials: 'same-origin',
+                });
+                if (!r.ok) throw new Error(`upload url request failed (${r.status})`);
+                return (await r.json()).attributes.url;
+            },
 
             handleDragEnter(e) {
                 e.preventDefault();
@@ -259,7 +269,7 @@
                 const fileData = this.uploadQueue[index];
                 fileData.status = 'uploading';
                 try {
-                    const uploadUrl = await $wire.getUploadUrl();
+                    const uploadUrl = await this.fetchUploadUrl();
                     const url = new URL(uploadUrl);
                     let basePath = @js($this->path);
 


### PR DESCRIPTION
closes #2326 

multi-file uploads were 404ing after the first file. $wire.getUploadUrl() goes through livewire's request batcher, so the parallel uploadFile() loop (maxConcurrent=3) handed every concurrent caller the same jwt. wings invalidates the token after first use, so files 2+ all hit 404.

fetching the existing /api/client/servers/{uuid}/files/upload route directly bypasses the batcher, each fetch is independent so every upload gets its own jwt. the livewire helper got dropped along with its imports, nothing was calling it after the swap.

the other option was pre-fetching urls sequentially via $wire.getUploadUrl() before the parallel loop. stays in the livewire idiom and the diff is smaller, but it's one round-trip per file before any upload starts (a 100-file batch sits for like 5s before sending the first byte). went with the http route for the parallel-friendliness, i'm open to the sequential shape if people prefer.

i noticed that the upload pipeline is duplicated across file-upload.blade and list-files.blade. i didn't touch it, n just patched both.

tested on panel b35 + wings b25: parallel batches all succeed, weird filenames get handled, nested folders via drag-drop, also forced a 403 on the url fetch to confirm the failure UX still surfaces a per-file error.