### PR TITLE
move some hardcoded ratelimits for the api to env vars

### DIFF
--- a/app/Enums/ResourceLimit.php
+++ b/app/Enums/ResourceLimit.php
@@ -43,12 +43,12 @@ enum ResourceLimit: string
     public function limit(): Limit
     {
         return match ($this) {
-            self::Websocket => Limit::perMinute(5),
-            self::BackupRestore => Limit::perMinutes(15, 3),
-            self::DatabaseCreate => Limit::perMinute(2),
-            self::SubuserCreate => Limit::perMinutes(15, 10),
-            self::FilePull => Limit::perMinutes(10, 5),
-            default => Limit::perMinute(2),
+            self::Websocket => Limit::perMinutes(config('http.rate_limit.websocket_period'), config('http.rate_limit.websocket')),
+            self::BackupRestore => Limit::perMinutes(config('http.rate_limit.backup_restore_period'), config('http.rate_limit.backup_restore')),
+            self::DatabaseCreate => Limit::perMinutes(config('http.rate_limit.database_create_period'), config('http.rate_limit.database_create')),
+            self::SubuserCreate => Limit::perMinutes(config('http.rate_limit.subuser_create_period'), config('http.rate_limit.subuser_create')),
+            self::FilePull => Limit::perMinutes(config('http.rate_limit.file_pull_period'), config('http.rate_limit.file_pull')),
+            default => Limit::perMinutes(config('http.rate_limit.default_period'), config('http.rate_limit.default')),
         };
     }
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -69,10 +69,10 @@ class RouteServiceProvider extends ServiceProvider
         // trigger email spam.
         RateLimiter::for('authentication', function (Request $request) {
             if ($request->route()->named('auth.post.forgot-password')) {
-                return Limit::perMinute(2)->by($request->ip());
+                return Limit::perMinutes(config('http.rate_limit.password_reset_period'), config('http.rate_limit.password_reset'))->by($request->ip());
             }
 
-            return Limit::perMinute(10);
+            return Limit::perMinutes(config('http.rate_limit.auth_period'), config('http.rate_limit.auth'));
         });
 
         // Configure the throttles for both the application and client APIs below.

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -67,6 +67,7 @@ class RouteServiceProvider extends ServiceProvider
         // a limit of 10 requests per minute, for the forgot password endpoint apply a
         // limit of two per minute for the requester so that there is less ability to
         // trigger email spam.
+        // the ratelimits refrenced above are now configured by env vars (check config/http.php for more details)
         RateLimiter::for('authentication', function (Request $request) {
             if ($request->route()->named('auth.post.forgot-password')) {
                 return Limit::perMinutes(config('http.rate_limit.password_reset_period'), config('http.rate_limit.password_reset'))->by($request->ip());

--- a/config/http.php
+++ b/config/http.php
@@ -12,10 +12,34 @@ return [
     |
     */
     'rate_limit' => [
-        'client_period' => 1,
+        'client_period' => env('APP_API_CLIENT_RATELIMIT_PERIOD', 1),
         'client' => env('APP_API_CLIENT_RATELIMIT', 256),
 
-        'application_period' => 1,
+        'application_period' => env('APP_API_APPLICATION_RATELIMIT_PERIOD', 1),
         'application' => env('APP_API_APPLICATION_RATELIMIT', 256),
+
+        'auth_period' => env('APP_API_AUTH_RATELIMIT_PERIOD', 1),
+        'auth' => env('APP_API_AUTH_RATELIMIT', 10),
+
+        'password_reset_period' => env('APP_API_PASSWORD_RESET_RATELIMIT_PERIOD', 1),
+        'password_reset' => env('APP_API_PASSWORD_RESET_RATELIMIT', 2),
+
+        'websocket_period' => env('APP_API_WEBSOCKET_RATELIMIT_PERIOD', 1),
+        'websocket' => env('APP_API_WEBSOCKET_RATELIMIT', 5),
+
+        'backup_restore_period' => env('APP_API_BACKUP_RESTORE_RATELIMIT_PERIOD', 15),
+        'backup_restore' => env('APP_API_BACKUP_RESTORE_RATELIMIT', 3),
+
+        'database_create_period' => env('APP_API_DATABASE_CREATE_RATELIMIT_PERIOD', 1),
+        'database_create' => env('APP_API_DATABASE_CREATE_RATELIMIT', 2),
+
+        'subuser_create_period' => env('APP_API_SUBUSER_CREATE_RATELIMIT_PERIOD', 15),
+        'subuser_create' => env('APP_API_SUBUSER_CREATE_RATELIMIT', 10),
+
+        'file_pull_period' => env('APP_API_FILE_PULL_RATELIMIT_PERIOD', 10),
+        'file_pull' => env('APP_API_FILE_PULL_RATELIMIT', 5),
+
+        'default_period' => env('APP_API_DEFAULT_RATELIMIT_PERIOD', 1),
+        'default' => env('APP_API_DEFAULT_RATELIMIT', 2),
     ],
 ];

--- a/config/http.php
+++ b/config/http.php
@@ -7,7 +7,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Defines the rate limit for the number of requests that can be
-    | executed against the client and internal (application) APIs along with 
+    | executed against the client and internal (application) APIs along with
     | certain other endpoints over a defined period (1 minute for most)
     */
     'rate_limit' => [

--- a/config/http.php
+++ b/config/http.php
@@ -6,10 +6,9 @@ return [
     | API Rate Limits
     |--------------------------------------------------------------------------
     |
-    | Defines the rate limit for the number of requests per minute that can be
-    | executed against both the client and internal (application) APIs over the
-    | defined period (by default, 1 minute).
-    |
+    | Defines the rate limit for the number of requests that can be
+    | executed against the client and internal (application) APIs along with 
+    | certain other endpoints over a defined period (1 minute for most)
     */
     'rate_limit' => [
         'client_period' => env('APP_API_CLIENT_RATELIMIT_PERIOD', 1),


### PR DESCRIPTION
while making an app using the api i ran into ratelimits that didn't make sense, turns out there are ratelimits outside of the client and application api rate limits, this moves the ones i found, including the auth and password reset ratelimits to using env vars for configuration .  

ideally this would be in admin panel area where the client and application api ratelimits are but i know practically nothing about php, larvel , filament or the other things this project uses. i have programmed a decent amt and it turns combining that with some copy pasting and a linter/syntax checker ends up working out ok.

feel free to suggest better names for the config values, whether for naming conventions or something else  

my main concern is that these ratelimits are able to be configured in a docker environment without needing to override the file via docker volume bind