### PR TITLE
chore(i18n): Automate Crowdin source sync and translation pull workflows

### DIFF
--- a/.github/workflows/add-crowdin-keys.yml
+++ b/.github/workflows/add-crowdin-keys.yml
@@ -1,0 +1,29 @@
+name: Add Crowdin Translation Strings
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'lang/en/**'
+      - 'crowdin.yml'
+  workflow_dispatch:
+
+jobs:
+  synchronize-with-crowdin:
+    name: Synchronize Sources with Crowdin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Sync Sources to Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: '665842'
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,0 +1,33 @@
+name: Update translations
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
+  workflow_dispatch:
+
+jobs:
+  update-translations:
+    name: Pull Translations from Crowdin
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Sync Translations from Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          create_pull_request: true
+          pull_request_title: 'feat: Update translations'
+          pull_request_body: 'Automated Pull Request containing the latest translations from Crowdin.'
+          pull_request_base_branch_name: 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: '665842'
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -23,6 +23,7 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
+          export_only_approved: true
           create_pull_request: true
           pull_request_title: 'feat: Update translations'
           pull_request_body: 'Automated Pull Request containing the latest translations from Crowdin.'


### PR DESCRIPTION
This PR introduces two GitHub Actions workflows utilizing the official `crowdin/github-action` to automate our localization process seamlessly, without interrupting developer workflows:

1. **`add-crowdin-keys.yml`**: Automatically synchronizes our English source strings (`lang/en/**/*.php`) to our Crowdin project whenever they are updated on the `main` branch. This action automatically adds new strings and removes deleted strings from Crowdin.
2. **`update-translations.yml`**: A scheduled workflow (runs once a week) that downloads all approved translations from Crowdin and bundles them into a single automated Pull Request against the `main` branch. Maintainers can simply review and merge this PR when ready, keeping commit history clean.

Because we already have the standard `crowdin.yml` mapping configured in the repository, the official action natively maps English sources to all translation targets perfectly. 

## Setup Required by Maintainers
For these actions to communicate with Crowdin, a repository secret needs to be added:
1. Generate a **Personal Access Token** in your Crowdin Account Settings.
2. Go to this repository's **Settings > Secrets and variables > Actions**.
3. Add a new repository secret:
   - **Name:** `CROWDIN_PERSONAL_TOKEN`
   - **Secret:** *(Paste your Crowdin Personal Access Token here)*

*(Note: The `CROWDIN_PROJECT_ID` is hardcoded to `665842` in the workflows since it's public project information).*

## Testing
- You can manually trigger the **Add Crowdin Translation Strings** workflow from the Actions tab to verify it pushes English sources successfully.
- You can manually trigger the **Update translations** workflow from the Actions tab to verify it successfully creates a PR with translation updates.