### PR TITLE
ci: Fix Crowdin synchronization paths and optimize configs

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -1,4 +1,4 @@
-name: Update translations
+name: Download Crowdin Translations
 
 on:
   schedule:
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-translations:
-    name: Pull Translations from Crowdin
+  download-translations:
+    name: Download Translations from Crowdin
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -17,18 +17,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Sync Translations from Crowdin
+      - name: Download Translations from Crowdin
         uses: crowdin/github-action@v2
         with:
           upload_sources: false
           upload_translations: false
           download_translations: true
           export_only_approved: true
+          localization_branch_name: i18n_crowdin_translations
           create_pull_request: true
-          pull_request_title: 'feat: Update translations'
-          pull_request_body: 'Automated Pull Request containing the latest translations from Crowdin.'
+          pull_request_title: 'New Crowdin Translations'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
           pull_request_base_branch_name: 'main'
+          crowdin_branch_name: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: '665842'
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/upload-sources.yml
+++ b/.github/workflows/upload-sources.yml
@@ -1,4 +1,4 @@
-name: Add Crowdin Translation Strings
+name: Upload Crowdin Sources
 
 on:
   push:
@@ -9,21 +9,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  synchronize-with-crowdin:
-    name: Synchronize Sources with Crowdin
+  upload-sources:
+    name: Upload Sources to Crowdin
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Sync Sources to Crowdin
+      - name: Upload Sources to Crowdin
         uses: crowdin/github-action@v2
         with:
           upload_sources: true
           upload_translations: false
           download_translations: false
+          crowdin_branch_name: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: '665842'
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,11 +1,14 @@
+project_id_env: "CROWDIN_PROJECT_ID"
+api_token_env: "CROWDIN_PERSONAL_TOKEN"
+base_path: "."
+preserve_hierarchy: true
+
 files:
-  - source: /lang/en/*.php
-    translation: /lang/%two_letters_code%/%original_file_name%
-  - source: /lang/en/admin
-    translation: /lang/%two_letters_code%/admin/%original_file_name%
-  - source: /lang/en/command
-    translation: /lang/%two_letters_code%/command/%original_file_name%
-  - source: /lang/en/dashboard
-    translation: /lang/%two_letters_code%/dashboard/%original_file_name%
-  - source: /lang/en/server
-    translation: /lang/%two_letters_code%/server/%original_file_name%
+  - source: "/lang/en/**/*.php"
+    translation: "/lang/%two_letters_code%/**/%original_file_name%"
+
+languages_mapping:
+  two_letters_code:
+    'zh-CN': 'zh_CN'
+    'zh-TW': 'zh_TW'
+    'pt-BR': 'pt_BR'


### PR DESCRIPTION
This PR resolves the synchronization failures between GitHub Actions and Crowdin. Previously, the workflow failed to locate translation files due to branch path mismatches, and specific locales were generating incorrect folder names.

**Changes**

* **GitHub Actions Workflows:**
  * Renamed workflow files to explicitly reflect their purpose (`upload-sources.yml` & `download-translations.yml`).
  * Added `crowdin_branch_name: main` to correctly target the Crowdin project branch and resolve "missing sources" errors.
  * Secured `CROWDIN_PROJECT_ID` by migrating it to GitHub Secrets.
  * Enforced least-privilege access by adding `permissions: contents: read` to the upload job.
  * Defined `localization_branch_name` for the download action to standardise the PR creation process.


* **Crowdin Configuration (`crowdin.yml`):**
  * Replaced hardcoded subdirectory paths with recursive wildcards (`/*.php`) for dynamic matching.
  * Added `preserve_hierarchy: true` to maintain the original repository structure during translation exports.
  * Implemented `languages_mapping` to ensure regional locales correctly output with underscores (`zh_TW`, `zh_CN`, `pt_BR`) instead of falling back to default two-letter codes.