### PR TITLE
Return empty array instead of null when plugin update checking fails

### DIFF
--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -279,7 +279,7 @@ class Plugin extends Model implements HasPluginSettings
                 report($exception);
             }
 
-            return null;
+            return [];
         });
     }
 


### PR DESCRIPTION
With `null` the update check is repeated each request which can slow down the panel.