### PR TITLE
Skip daemon RPC calls for servers on maintenance-mode nodes

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -457,6 +457,10 @@ class Server extends Model implements HasAvatar, Validatable
 
     public function retrieveStatus(): ContainerStatus
     {
+        if ($this->node->isUnderMaintenance()) {
+            return ContainerStatus::Missing;
+        }
+
         return cache()->remember("servers.$this->uuid.status", now()->addSeconds(15), function () {
             // @phpstan-ignore myCustomRules.forbiddenGlobalFunctions
             $details = app(DaemonServerRepository::class)->setServer($this)->getDetails();
@@ -470,6 +474,10 @@ class Server extends Model implements HasAvatar, Validatable
      */
     public function retrieveResources(): array
     {
+        if (!$this->retrieveStatus()->isStartingOrRunning()) {
+            return [];
+        }
+
         return cache()->remember("servers.$this->uuid.resources", now()->addSeconds(15), function () {
             // @phpstan-ignore myCustomRules.forbiddenGlobalFunctions
             $details = app(DaemonServerRepository::class)->setServer($this)->getDetails();

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -474,7 +474,7 @@ class Server extends Model implements HasAvatar, Validatable
      */
     public function retrieveResources(): array
     {
-        if (!$this->retrieveStatus()->isStartingOrRunning()) {
+        if ($this->node->isUnderMaintenance()) {
             return [];
         }
 


### PR DESCRIPTION
[**Discussion: Node disruption causes UX delay**](https://github.com/pelican-dev/panel/discussions/2369)

**Purpose**: Practical way to handle Wings node down, yet. Due to the nature of "Maintenance mode" option, runtime consequences must be known by operator, which should make it useful. This option will disengage most of the query process from the dashboard to the node in order to let the Wings instance in a safe state.

### What changed:

- `retrieveStatus()`: return Missing immediately if node is under maintenance
- `retrieveResources()`: return empty if server status is not starting/running, which includes Missing (from maintenance guard) and all stopped states