### PR TITLE
Fix dark mode

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -26,4 +26,4 @@
 
 @source '../../vendor/gboquizosanchez/filament-log-viewer/resources/views/**/*.blade.php';
 
-@variant dark (&:where(.dark, .dark *));
+@custom-variant dark (.dark &);

--- a/resources/views/docs/api-index.blade.php
+++ b/resources/views/docs/api-index.blade.php
@@ -6,9 +6,9 @@
     <title>API Documentation</title>
     @vite('resources/css/app.css')
 </head>
-<body class="bg-gray-100 min-h-screen flex items-center justify-center">
-    <div class="bg-white shadow-lg rounded-lg py-8 px-8 max-w-md w-full text-center">
-        <h2 class="text-xl font-bold text-gray-800 mb-4">API Documentation</h2>
+<body class="bg-gray-100 dark:bg-gray-950 min-h-screen flex items-center justify-center">
+    <div class="bg-white dark:bg-gray-900 shadow-lg rounded-lg py-8 px-8 max-w-md w-full text-center">
+        <h2 class="text-xl font-bold text-gray-800 dark:text-white mb-4">API Documentation</h2>
 
         <div class="mb-2">
             <a href="/docs/api/application" class="inline-flex items-center">

--- a/resources/views/filament/components/server-small-data-block.blade.php
+++ b/resources/views/filament/components/server-small-data-block.blade.php
@@ -1,4 +1,4 @@
-<div class="fi-small-stat-block grid grid-flow-row w-full p-3 rounded-lg bg-white shadow-sm overflow-hidden overflow-x-auto ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+<div class="fi-small-stat-block grid grid-flow-row w-full p-3 rounded-lg shadow-sm overflow-hidden overflow-x-auto ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
 @if ($isCopyable($value = $getValue()))
     <span class="cursor-pointer" x-on:click="
         navigator.clipboard.writeText(@js($value));


### PR DESCRIPTION
Recently, dark mode left some component in light theme, even with correct class applied. Retested on both theme.

- @variant → @custom-variant to decouple from built-in media query variant
- Drop :where() so .dark .dark\:bg-gray-900 has specificity (0,0,2,0) beating bg-white at (0,0,1,0)
- Remove redundant bg-white from server-small-data-block
- Add dark mode classes to api-index page