### PR TITLE
Fix docker issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,16 +74,14 @@ COPY --chown=root:www-data --chmod=770 --from=composerbuild /build .
 COPY --chown=root:www-data --chmod=770 --from=yarnbuild /build/public ./public
 
 # Create and remove directories
-RUN mkdir -p /pelican-data/storage /pelican-data/plugins /var/run/supervisord \
-    && rm -rf /var/www/html/plugins \
-# Symlinks for env, database, storage, and plugins
+RUN mkdir -p /pelican-data/storage /var/run/supervisord \
+# Symlinks for env, database, storage
     && ln -s  /pelican-data/.env /var/www/html/.env \
     && ln -s  /pelican-data/database/database.sqlite ./database/database.sqlite \
     && ln -s  /pelican-data/storage /var/www/html/public/storage \
     && ln -s  /pelican-data/storage /var/www/html/storage/app/public \
-    && ln -s  /pelican-data/plugins /var/www/html \
 # Allow www-data write permissions where necessary
-    && chown -R www-data: /pelican-data .env ./storage ./plugins ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
+    && chown -R www-data: /pelican-data .env ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R 770 /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \
     && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/ /var/www/html/composer.json /var/www/html/composer.lock
 # Configure Supervisor

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -79,16 +79,14 @@ COPY --chown=root:www-data --chmod=770 --from=composerbuild /build .
 COPY --chown=root:www-data --chmod=770 --from=yarnbuild /build/public ./public
 
 # Create and remove directories
-RUN mkdir -p /pelican-data/storage /pelican-data/plugins /var/run/supervisord \
-    && rm -rf /var/www/html/plugins \
-# Symlinks for env, database, storage, and plugins
+RUN mkdir -p /pelican-data/storage /var/run/supervisord \
+# Symlinks for env, database, storage
     && ln -s  /pelican-data/.env /var/www/html/.env \
     && ln -s  /pelican-data/database/database.sqlite ./database/database.sqlite \
     && ln -s  /pelican-data/storage /var/www/html/public/storage \
     && ln -s  /pelican-data/storage /var/www/html/storage/app/public \
-    && ln -s  /pelican-data/plugins /var/www/html \
 # Allow www-data write permissions where necessary
-    && chown -R www-data: /pelican-data .env ./storage ./plugins ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
+    && chown -R www-data: /pelican-data .env ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R 770 /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \
     && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/ /var/www/html/composer.json /var/www/html/composer.lock
 

--- a/compose-bind.yml
+++ b/compose-bind.yml
@@ -1,7 +1,7 @@
 x-common:
   panel:
     &panel-environment
-    APP_URL: "https://localhost" # can be set to 'http://localhost' on port 80 only
+    APP_URL: "http://localhost"
     LE_EMAIL: "USEYOUROWNEMAILHERE@example.com" # email to be used for let's encrypt certificates
     APP_DEBUG: "false"
     APP_ENV: "production"
@@ -19,15 +19,6 @@ x-common:
     # MAIL_PASSWORD: ""
     # MAIL_SCHEME: ""
 
-  database:
-    &db-environment
-    # Do not remove the "&db-password" from the end of the line below, it is important
-    # for Panel functionality.
-    MYSQL_ROOT_PASSWORD: "SUPERNEEDSTOCHANGE"
-    MYSQL_PASSWORD: &db-password "NEEDSTOCHANGE"
-    MYSQL_DATABASE: &db-database "panel"
-    MYSQL_USER: &db-username "pelican"
-
 #
 # ------------------------------------------------------------------------------------------
 # DANGER ZONE BELOW
@@ -37,20 +28,8 @@ x-common:
 #
 
 services:
-  database:
-    image: mariadb:10.11
-    restart: always
-    command: --default-authentication-plugin=mysql_native_password
-    volumes:
-      - pelican-db:/var/lib/mysql
-    environment:
-      <<: *db-environment
-
-  cache:
-    image: redis:alpine
-    restart: always
-
   panel:
+    user: "0:0"
     image: ghcr.io/pelican-dev/panel:latest
     build: .
     restart: unless-stopped
@@ -61,41 +40,13 @@ services:
       - "443:443"
       # - "81:80" # if you are behind a proxy uncomment this line and comment out 80 and 443
       # - "9000:9000" # enable when not using caddy to be able to reach php-fpm
-    links:
-      - database
-      - cache
     extra_hosts:
       - "host.docker.internal:host-gateway" # shows the panel on the internal docker network as well. usually '172.17.0.1'
     volumes:
-      - pelican-data:/pelican-data
-      - pelican-logs:/var/www/html/storage/logs
-      - type: volume
-        source: pelican-data
-        target: /var/www/html/plugins
-        volume:
-          subpath: plugins
+      - /opt/pelican/data:/pelican-data
+      - /opt/pelican/logs:/var/www/html/storage/logs
+      - /opt/pelican/plugins:/var/www/html/plugins
     environment:
       <<: [*panel-environment, *mail-environment]
       XDG_DATA_HOME: /pelican-data
       # SKIP_CADDY: true # enable when not using caddy.
-      CACHE_STORE: "redis"
-      SESSION_DRIVER: "redis"
-      QUEUE_CONNECTION: "redis"
-      REDIS_HOST: "cache"
-      DB_CONNECTION: "mariadb"
-      DB_HOST: "database"
-      DB_PORT: "3306"
-      DB_DATABASE: *db-database
-      DB_USERNAME: *db-username
-      DB_PASSWORD: *db-password
-
-volumes:
-  pelican-data:
-  pelican-logs:
-  pelican-db:
-
-networks:
-  default:
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16

--- a/compose.yml
+++ b/compose.yml
@@ -44,6 +44,12 @@ services:
     volumes:
       - pelican-data:/pelican-data
       - pelican-logs:/var/www/html/storage/logs
+      - type: volume
+        source: pelican-data
+        target: /var/www/html/plugins
+        volume:
+          subpath: plugins
+
     environment:
       <<: [*panel-environment, *mail-environment]
       XDG_DATA_HOME: /pelican-data

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,1 +1,2 @@
 * * * * * php /var/www/html/artisan schedule:run
+0 0 * * * php /var/www/html/artisan p:egg:check-updates 


### PR DESCRIPTION
resolves #2323
resolves #2260

No longer creates the plugins folder.
Use a sub-volume mount for plugins.
Resolves an issue for themes as well due to relative pathing Crontab now runs egg update check daily.

Adds a new compose that runs as root for bind mounts. It would be better to use volumes or own the bind mounts to 82:82 instead.