### PR TITLE
docker: Update php to 8.5 and node to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN composer install --no-dev --no-interaction --no-autoloader --no-scripts
 # ================================
 # Stage 1-2: Yarn Install
 # ================================
-FROM --platform=$TARGETOS/$TARGETARCH node:20-alpine AS yarn
+FROM --platform=$TARGETOS/$TARGETARCH node:22-alpine AS yarn
 
 WORKDIR /build
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 # ================================
 # Stage 0: Build PHP Base Image
 # ================================
-FROM --platform=$TARGETOS/$TARGETARCH php:8.4-fpm-alpine
+FROM --platform=$TARGETOS/$TARGETARCH php:8.5-fpm-alpine
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.13-labs
 # Pelican Development Dockerfile
 
-FROM --platform=$TARGETOS/$TARGETARCH php:8.4-fpm-alpine AS base
+FROM --platform=$TARGETOS/$TARGETARCH php:8.5-fpm-alpine AS base
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
@@ -26,7 +26,7 @@ RUN composer install --no-dev --no-interaction --no-autoloader --no-scripts
 # ================================
 # Stage 1-2: Yarn Install
 # ================================
-FROM --platform=$TARGETOS/$TARGETARCH node:20-alpine AS yarn
+FROM --platform=$TARGETOS/$TARGETARCH node:22-alpine AS yarn
 
 WORKDIR /build
 


### PR DESCRIPTION
# Changes

- Bump our docker builds from php 8.4 to 8.5
- Bump our docker build from nodejs 20 to 22

This way they use the same version as our github action releases