### PR TITLE
Add back `bg-white` to small stat

### DIFF
--- a/resources/views/filament/components/server-small-data-block.blade.php
+++ b/resources/views/filament/components/server-small-data-block.blade.php
@@ -1,4 +1,4 @@
-<div class="fi-small-stat-block grid grid-flow-row w-full p-3 rounded-lg shadow-sm overflow-hidden overflow-x-auto ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+<div class="fi-small-stat-block grid grid-flow-row w-full p-3 rounded-lg bg-white shadow-sm overflow-hidden overflow-x-auto ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
 @if ($isCopyable($value = $getValue()))
     <span class="cursor-pointer" x-on:click="
         navigator.clipboard.writeText(@js($value));


### PR DESCRIPTION
Followup for #2373, turns out the `bg-white` was not redundant.

Before:
<img width="1496" height="208" alt="grafik" src="https://github.com/user-attachments/assets/7a687c4b-b28e-48b5-8503-d34bd2a3ffc7" />

After:
<img width="1486" height="218" alt="grafik" src="https://github.com/user-attachments/assets/7ac87fed-fc7d-40d4-84d2-6f6a3f5430e0" />