### PR TITLE
Fix Crowdin language mapping and integrate automated Pint formatting

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -33,10 +33,10 @@ jobs:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
       - name: Run Laravel Pint
-        uses: aglipanci/laravel-pint-action@2.4
+        uses: aglipanci/laravel-pint-action@8eedec46a1856977c41667f9c66d5562fa3f9c08 # 2.4
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update translations and format with pint'

--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -24,13 +24,23 @@ jobs:
           upload_translations: false
           download_translations: true
           export_only_approved: true
-          localization_branch_name: i18n_crowdin_translations
-          create_pull_request: true
-          pull_request_title: 'New Crowdin Translations'
-          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
-          pull_request_base_branch_name: 'main'
+          push_translations: false
+          create_pull_request: false
           crowdin_branch_name: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Run Laravel Pint
+        uses: aglipanci/laravel-pint-action@2.4
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: update translations and format with pint'
+          title: 'New Crowdin Translations'
+          body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action), formatted by Laravel Pint.'
+          branch: 'i18n_crowdin_translations'
+          base: 'main'

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,9 +6,8 @@ preserve_hierarchy: true
 files:
   - source: "/lang/en/**/*.php"
     translation: "/lang/%two_letters_code%/**/%original_file_name%"
-
-languages_mapping:
-  two_letters_code:
-    'zh-CN': 'zh_CN'
-    'zh-TW': 'zh_TW'
-    'pt-BR': 'pt_BR'
+    languages_mapping:
+      two_letters_code:
+        'zh-CN': 'zh_CN'
+        'zh-TW': 'zh_TW'
+        'pt-BR': 'pt_BR'


### PR DESCRIPTION
This PR resolves two significant issues with the automated Crowdin translation workflow:

1. Corrected Crowdin Language Mapping
Previously, Crowdin was downloading languages with underscores (such as zh_CN, zh_TW, pt_BR) into incorrect base language directories (like zh, pt). The root cause was that the languages_mapping block in crowdin.yml was placed at the root level. This PR correctly indents the mapping configuration under the files array so Crowdin parses it and preserves the correct directory names.

2. Integrated Laravel Pint Formatting
The Crowdin exporter defaults to using double quotes for strings, which violates the project's Laravel styling rules and causes CI checks to fail. 
To fix this, the download-translations workflow has been refactored. We now intercept the downloaded translations and run them through the aglipanci/laravel-pint-action (which respects the project's pint.json) before committing. Finally, peter-evans/create-pull-request is used to open the PR. This ensures all automated translation PRs will be perfectly formatted and pass CI out of the box.

Action Settings Update Required!
For this new workflow to successfully create Pull Requests, a repository admin must update the following setting:
1. Go to repository Settings > Actions > General.
2. Scroll down to the Workflow permissions section.
3. Check the box for "Allow GitHub Actions to create and approve pull requests".
4. Click Save.