### PR TITLE
Speed up ci checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,6 +205,13 @@ jobs:
       matrix:
         php: [8.5]
         database: ["postgres:17", "postgres:18"]
+        include:
+          # postgres:17 stores data in /var/lib/postgresql/data, 18+ requires a
+          # single mount at /var/lib/postgresql and errors on a data submount
+          - database: "postgres:17"
+            tmpfs: /var/lib/postgresql/data
+          - database: "postgres:18"
+            tmpfs: /var/lib/postgresql
     services:
       database:
         image: ${{ matrix.database }}
@@ -216,8 +223,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --tmpfs /var/lib/postgresql:rw
-          --tmpfs /var/lib/postgresql/data:rw
+          --tmpfs ${{ matrix.tmpfs }}:rw
           --health-cmd pg_isready
           --health-interval 2s
           --health-timeout 5s

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
           MYSQL_DATABASE: testing
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --tmpfs /var/lib/mysql:rw --health-cmd="mysqladmin ping" --health-interval=2s --health-timeout=5s --health-retries=30
     env:
       DB_CONNECTION: mysql
       DB_HOST: 127.0.0.1
@@ -129,12 +129,6 @@ jobs:
           DB_PORT: ${{ job.services.database.ports[3306] }}
           DB_USERNAME: root
 
-      - name: Unit tests
-        run: vendor/bin/pest tests/Unit --parallel --do-not-fail-on-phpunit-warning
-        env:
-          DB_HOST: UNIT_NO_DB
-          SKIP_MIGRATIONS: true
-
       - name: Integration tests
         run: vendor/bin/pest tests/Integration --parallel --do-not-fail-on-phpunit-warning
         env:
@@ -157,7 +151,7 @@ jobs:
           MYSQL_DATABASE: testing
         ports:
           - 3306
-        options: --health-cmd="mariadb-admin ping || mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --tmpfs /var/lib/mysql:rw --health-cmd="mariadb-admin ping || mysqladmin ping" --health-interval=2s --health-timeout=5s --health-retries=30
     env:
       DB_CONNECTION: mariadb
       DB_HOST: 127.0.0.1
@@ -197,12 +191,6 @@ jobs:
           DB_PORT: ${{ job.services.database.ports[3306] }}
           DB_USERNAME: root
 
-      - name: Unit tests
-        run: vendor/bin/pest tests/Unit --parallel --do-not-fail-on-phpunit-warning
-        env:
-          DB_HOST: UNIT_NO_DB
-          SKIP_MIGRATIONS: true
-
       - name: Integration tests
         run: vendor/bin/pest tests/Integration --parallel --do-not-fail-on-phpunit-warning
         env:
@@ -228,10 +216,12 @@ jobs:
         ports:
           - 5432:5432
         options: >-
+          --tmpfs /var/lib/postgresql:rw
+          --tmpfs /var/lib/postgresql/data:rw
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 30
     env:
       DB_CONNECTION: pgsql
       DB_HOST: 127.0.0.1
@@ -268,12 +258,6 @@ jobs:
 
       - name: Run Migrations
         run: php artisan migrate --force --seed
-
-      - name: Unit tests
-        run: vendor/bin/pest tests/Unit --parallel --do-not-fail-on-phpunit-warning
-        env:
-          DB_HOST: UNIT_NO_DB
-          SKIP_MIGRATIONS: true
 
       - name: Integration tests
         run: vendor/bin/pest tests/Integration --parallel --do-not-fail-on-phpunit-warning


### PR DESCRIPTION
Results from the [first green run](https://github.com/pelican-dev/panel/actions/runs/27371664222) vs the [baseline on main](https://github.com/pelican-dev/panel/actions/runs/27357631929): total wall-clock **2m39s**, down from ~4m34s (**~42% faster**).

| Job | Before | After |
|---|---|---|
| MySQL 9.6 | 4m26s | 2m18s |
| MySQL 8.4 | 3m07s | 2m36s |
| MariaDB 10.11 | 2m41s | 1m42s |
| MariaDB 11.4 | 2m15s | 2m06s |
| PostgreSQL 17 / 18 | ~2m38s | 1m54s / 1m48s |
| SQLite (unchanged) | ~2m | ~2m |