### PR TITLE
Add can check to suspend actions

### DIFF
--- a/app/Filament/Admin/Resources/Users/RelationManagers/ServersRelationManager.php
+++ b/app/Filament/Admin/Resources/Users/RelationManagers/ServersRelationManager.php
@@ -26,7 +26,8 @@ class ServersRelationManager extends RelationManager
             ->searchable(false)
             ->heading(trans('admin/user.servers'))
             ->headerActions([
-                Action::make('toggleSuspend')
+                Action::make('toggle_suspend')
+                    ->authorize(fn () => user()?->can('update server'))
                     ->hidden(fn () => $user->servers()
                         ->whereNot('status', ServerState::Suspended)
                         ->orWhereNull('status')
@@ -38,7 +39,8 @@ class ServersRelationManager extends RelationManager
                         collect($user->servers)->filter(fn ($server) => !$server->isSuspended())
                             ->each(fn ($server) => $suspensionService->handle($server, SuspendAction::Suspend));
                     }),
-                Action::make('toggleUnsuspend')
+                Action::make('toggle_unsuspend')
+                    ->authorize(fn () => user()?->can('update server'))
                     ->hidden(fn () => $user->servers()->where('status', ServerState::Suspended)->count() === 0)
                     ->label(trans('admin/server.unsuspend_all'))
                     ->color('primary')


### PR DESCRIPTION
Makes sure you can only (un-) suspend all servers of a user if you can `update` servers in general.